### PR TITLE
Skip fzf finder if the list contains a single item

### DIFF
--- a/src/arg.sh
+++ b/src/arg.sh
@@ -4,8 +4,10 @@ ARG_REGEX="<[0-9a-zA-Z_]+>"
 ARG_DELIMITER="£"
 
 arg::dict() {
-   local -r fn="$(awk -F'---' '{print $1}')"
-   local -r opts="$(awk -F'---' '{print $2}')"
+   # capture stdin because subsequent attempts to read it fail
+   local -r stdin="$(cat -)"
+   local -r fn="$(echo "$stdin" | awk -F'---' '{print $1}')"
+   local -r opts="$(echo "$stdin" | awk -F'---' '{print $2}')"
 
    dict::new fn "$fn" opts "$opts"
 }

--- a/src/arg.sh
+++ b/src/arg.sh
@@ -5,7 +5,7 @@ ARG_DELIMITER="£"
 
 arg::dict() {
    # capture stdin because subsequent attempts to read it fail
-   local -r stdin="$(cat -)"
+   local -r stdin="$(cat)"
    local -r fn="$(echo "$stdin" | awk -F'---' '{print $1}')"
    local -r opts="$(echo "$stdin" | awk -F'---' '{print $2}')"
 

--- a/src/opts.sh
+++ b/src/opts.sh
@@ -13,6 +13,7 @@ opts::eval() {
    local interpolation=true
    local preview=true
    local path="${NAVI_PATH:-${NAVI_DIR:-${SCRIPT_DIR}/cheats}}"
+   local autoselect=true
 
    for arg in "$@"; do
       case $wait_for in
@@ -33,8 +34,9 @@ opts::eval() {
          search) entry_point="search"; wait_for="search" ;;
          preview) entry_point="preview"; wait_for="preview" ;;
          q|query) wait_for="query" ;;
+         --no-autoselect) autoselect=false ;;
       esac
    done
 
-   dict::new entry_point "$entry_point" print "$print" interpolation "$interpolation" preview "$preview" query "${query:-}" path "$path"
+   dict::new entry_point "$entry_point" print "$print" interpolation "$interpolation" preview "$preview" query "${query:-}" path "$path" autoselect "$autoselect"
 }

--- a/src/ui.sh
+++ b/src/ui.sh
@@ -14,6 +14,7 @@ ui::select() {
    local -r query="$(dict::get "$OPTIONS" query)"
    local -r entry_point="$(dict::get "$OPTIONS" entry_point)"
    local -r preview="$(dict::get "$OPTIONS" preview)"
+   local -r autoselect="$(dict::get "$OPTIONS" autoselect)"
 
    local args=()
    args+=("-i")
@@ -28,6 +29,9 @@ ui::select() {
    if [ "$entry_point" = "search" ]; then
       args+=("--header")
       args+=("Displaying online results. Please refer to 'navi --help' for details")
+   fi
+   if [ "$autoselect" == true ]; then
+      args+=("--select-1")
    fi
 
    echo "$cheats" \

--- a/src/ui.sh
+++ b/src/ui.sh
@@ -30,7 +30,7 @@ ui::select() {
       args+=("--header")
       args+=("Displaying online results. Please refer to 'navi --help' for details")
    fi
-   if [ "$autoselect" == true ]; then
+   if [ "$autoselect" ]; then
       args+=("--select-1")
    fi
 


### PR DESCRIPTION
Hey, thanks for making such a great tool! I stumbled across issue #44 and thought I'd chip in.

My implementation uses fzf's `--select-1` [option][option] to have it skip the finder screen and autoselect the only item in the list.

Using the default cheats that come with navi, it can be tested by starting navi with a query like so:
```bash
navi query "'uncordon"
```
Note: the [single quote][syntax] in the query tells fzf to search for the exact string "uncordon" rather than fuzzy searching for it.

Running the above command will jump you directly into the `kubectl uncordon` command.

Removing the single quote will yield multiple matches and jump you into the fzf finder screen.

Let me know if there's anything more you need in this pull request!

[option]: https://github.com/junegunn/fzf/blob/master/src/options.go#L81
[syntax]: https://github.com/junegunn/fzf#search-syntax