### PR TITLE
Limit cheat for selection

### DIFF
--- a/src/cheat.sh
+++ b/src/cheat.sh
@@ -51,7 +51,15 @@ cheat::pretty() {
       /^%/ { tags=" ["substr($0, 3)"]"; next }
       /^#/ { print color(4, $0) color(60, tags); next }
       /^\$/ { next }
-   NF { print color(7, $0) color(60, tags); next }'
+      NF { print color(7, $0) color(60, tags); next }'
+}
+
+cheat::_until_percentage() {
+   awk 'BEGIN { count=0; }
+
+      /^%/ { if (count >= 1) exit; 
+             else { count++; print $0; next; } } 
+           { print $0 }'
 }
 
 cheat::from_selection() {
@@ -62,5 +70,6 @@ cheat::from_selection() {
 
    echo "$cheats" \
       | grep "% ${tags}" -A99999 \
+      | cheat::_until_percentage \
       || (echoerr "No valid cheatsheet!"; exit 67)
 }

--- a/src/misc.sh
+++ b/src/misc.sh
@@ -27,3 +27,9 @@ url::open() {
    local -r cmd="$(platform::existing_command "${BROWSER:-}" xdg-open open google-chrome firefox)"
    "$cmd" "$@"
 }
+
+tap() {
+   local -r input="$(cat)"
+   echoerr "$input"
+   echo "$input"
+}


### PR DESCRIPTION
Say we have a cheat with a free input for `<foo>` and there's another cheat with suggestions for `<foo>`. If you select a command from the first cheat, the suggestions in the second cheat would be used, before this PR.