### PR TITLE
navi fish plugin with ability to edit commandline

### DIFF
--- a/navi.plugin.fish
+++ b/navi.plugin.fish
@@ -1,21 +1,17 @@
-function navi-widget -d 'Call navi'
-  set -q NAVI_USE_FZF_ALL_INPUTS; or set -l NAVI_USE_FZF_ALL_INPUTS "true"
-  begin
-    navi --print | while read -l r; set result $result $r; end
-
-    if [ -n "$result" ]
-      echo $result
-
-      # Remove last token from commandline.
-      commandline -t ""
+function navi_key_bindings
+  function navi-widget -d "Show cheat sheet"
+    set -q FZF_TMUX_HEIGHT; or set FZF_TMUX_HEIGHT 40%
+    begin
+      set -lx FZF_DEFAULT_OPTS "--height $FZF_TMUX_HEIGHT $FZF_DEFAULT_OPTS --tiebreak=index --bind=ctrl-r:toggle-sort $FZF_CTRL_R_OPTS +m"
+      stty sane
+      env NAVI_USE_FZF_ALL_INPUTS=true navi --print query (commandline)  | perl -pe 'chomp if eof' | read -lz result
+      and commandline -- $result
     end
+    commandline -f repaint
   end
 
-  # commandline -f repaint
-end
-
-bind \cg navi-widget
-
-if bind -M insert > /dev/null 2>&1
-  bind -M insert \cg navi-widget
+  bind \cg navi-widget
+  if bind -M insert > /dev/null 2>&1
+    bind -M insert \cg navi-widget
+  end
 end


### PR DESCRIPTION
here's my version of the fish plugin. I adapted it from the fzf plugin which allows to go through the command line history (ctrl-r). the fzf_tmux_height  variables don't seem to have an effect. 
there's also an issue where if you cancel navi (ctrl-c), you still have some invisible ^C / ctrl-c character left in the commandline. So your next command will not work unless you press ctrl-c again. This should probably be fixed somehow. 
I had a problem where the line where I call navi would show prompts when run from the shell, but not in the function. I searched around the fish shell issues and running "stty sane" was suggested as a solution. 