### PR TITLE
follow symlinks for cheatsheet directories

### DIFF
--- a/src/cheat.sh
+++ b/src/cheat.sh
@@ -2,7 +2,7 @@
 
 cheat::find() {
    for path in $(echo "$NAVI_PATH" | tr ':' '\n'); do
-      find "$path" -iname '*.cheat'
+      find -L "$path" -iname '*.cheat'
    done
 }
 


### PR DESCRIPTION
## What does this do

This modifies `cheat::find()` to follow symbolic links on disk. This allows users who symlink their dotfiles to `~` to keep their custom cheatsheets in their dotfiles repo.

## How to test

* [X] Create a new cheatsheet somewhere on disk
* [X] Create a symbolic link to that directory inside of your user's home directory
* [X] Set the path for navi cheatsheets to the symbolic link
* [X] Invoke navi
* [X] Ensure cheatsheets are visible

