### PR TITLE
Allow overriding FZF variables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,7 +89,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "navi"
-version = "2.0.5"
+version = "2.0.6"
 dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "raw_tty 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "navi"
-version = "2.0.5"
+version = "2.0.6"
 authors = ["Denis Isidoro <denis_isidoro@live.com>"]
 edition = "2018"
 

--- a/scripts/fix
+++ b/scripts/fix
@@ -4,14 +4,19 @@ set -euo pipefail
 export NAVI_HOME="$(cd "$(dirname "$0")/.." && pwd)"
 source "${NAVI_HOME}/scripts/install"
 
+cd "$NAVI_HOME"
+
 header "Cargo nighly fix..."
-cargo +nightly fix --clippy -Z unstable-options 2> /dev/null || true
+cargo +nightly fix --clippy -Z unstable-options || true
 
 header "Cargo fix..."
-cargo fix 2> /dev/null || true
+cargo fix || true
 
 header "Cargo fmt..."
-cargo fmt 2> /dev/null || true
+cargo fmt || true
 
 header "dot code beautify..."
-find scripts -type f | xargs -I% dot code beautify 2> /dev/null || true
+find scripts -type f | xargs -I% dot code beautify % || true
+
+header "clippy..."
+cargo clippy || true

--- a/src/cmds/core.rs
+++ b/src/cmds/core.rs
@@ -65,6 +65,7 @@ fn prompt_with_suggestions(config: &Config, suggestion: &cheat::Value) -> String
     let mut opts = fzf::Opts {
         preview: false,
         autoselect: !config.no_autoselect,
+        overrides: config.fzf_overrides_var.as_ref(),
         ..Default::default()
     };
 

--- a/src/option.rs
+++ b/src/option.rs
@@ -34,12 +34,13 @@ pub struct Config {
     #[structopt(long)]
     pub no_preview: bool,
 
-    // #[structopt(long)]
-    // pub col_widths: Option<String>,
-    /// Overrides for fzf commands (must start with an empty space)
-    #[structopt(long)]
-    #[structopt(long)]
+    /// FZF overrides for cheat selection  (must start with an empty space)
+    #[structopt(long, env = "NAVI_FZF_OVERRIDES")]
     pub fzf_overrides: Option<String>,
+
+    /// FZF overrides for variable selection  (must start with an empty space)
+    #[structopt(long, env = "NAVI_FZF_OVERRIDES_VAR")]
+    pub fzf_overrides_var: Option<String>,
 
     #[structopt(subcommand)]
     pub cmd: Option<Command>,


### PR DESCRIPTION
`$FZF_DEFAULT_OPTS` won't work in some use cases because it has lower precedence then hardcoded settings such as `--exact`.

Usage:
```
export NAVI_FZF_OVERRIDES=" --no-exact"
navi
```

Fixes #232 