### PR TITLE
Fix crash when user enters a command that doesn't match any cheats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,7 +89,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "navi"
-version = "2.0.5"
+version = "2.0.7"
 dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "raw_tty 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "navi"
-version = "2.0.5"
+version = "2.0.7"
 authors = ["Denis Isidoro <denis_isidoro@live.com>"]
 edition = "2018"
 

--- a/src/cmds/core.rs
+++ b/src/cmds/core.rs
@@ -43,9 +43,7 @@ fn extract_from_selections(raw_output: &str, contains_key: bool) -> (&str, &str,
         "enter"
     };
 
-    let mut parts = lines.next()
-        .unwrap()
-        .split(display::DELIMITER);
+    let mut parts = lines.next().unwrap().split(display::DELIMITER);
     parts.next();
     parts.next();
     parts.next();

--- a/src/cmds/core.rs
+++ b/src/cmds/core.rs
@@ -42,13 +42,18 @@ fn extract_from_selections(raw_output: &str, contains_key: bool) -> (&str, &str,
     } else {
         "enter"
     };
-    let mut parts = lines.next().unwrap().split(display::DELIMITER);
+
+    let mut parts = lines.next()
+        .unwrap()
+        .split(display::DELIMITER);
     parts.next();
     parts.next();
     parts.next();
-    let tags = parts.next().unwrap();
+
+    let tags = parts.next().unwrap_or("");
     parts.next();
-    let snippet = parts.next().unwrap();
+
+    let snippet = parts.next().unwrap_or("");
     (key, tags, snippet)
 }
 


### PR DESCRIPTION
This fixes the crash when the user enters a command that does not match any cheat:
```
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', src/cmds/core.rs:52:16
stack backtrace:
   0: backtrace::backtrace::libunwind::trace
             at /Users/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.40/src/backtrace/libunwind.rs:88
   1: backtrace::backtrace::trace_unsynchronized
             at /Users/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.40/src/backtrace/mod.rs:66
   2: std::sys_common::backtrace::_print_fmt
             at src/libstd/sys_common/backtrace.rs:77
   3: <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt
             at src/libstd/sys_common/backtrace.rs:59
   4: core::fmt::write
             at src/libcore/fmt/mod.rs:1052
  5: std::io::Write::write_fmt
             at src/libstd/io/mod.rs:1426
   6: std::sys_common::backtrace::_print
             at src/libstd/sys_common/backtrace.rs:62
   7: std::sys_common::backtrace::print
             at src/libstd/sys_common/backtrace.rs:49
   8: std::panicking::default_hook::{{closure}}
             at src/libstd/panicking.rs:204
   9: std::panicking::default_hook
             at src/libstd/panicking.rs:224
  10: std::panicking::rust_panic_with_hook
             at src/libstd/panicking.rs:472
  11: rust_begin_unwind
             at src/libstd/panicking.rs:380
  12: core::panicking::panic_fmt
             at src/libcore/panicking.rs:85
  13: core::panicking::panic
             at src/libcore/panicking.rs:52
  14: core::option::Option<T>::unwrap
             at /rustc/b08d07143d2b61777d341f8658281adc0f2ac809/src/libcore/macros/mod.rs:10
  15: navi::cmds::core::extract_from_selections
             at src/cmds/core.rs:52
  16: navi::cmds::core::main
             at src/cmds/core.rs:158
  17: navi::main
             at src/main.rs:23
  18: std::rt::lang_start::{{closure}}
             at /rustc/b08d07143d2b61777d341f8658281adc0f2ac809/src/libstd/rt.rs:67
  19: std::rt::lang_start_internal::{{closure}}
             at src/libstd/rt.rs:52
  20: std::panicking::try::do_call
            at src/libstd/panicking.rs:305
  21: __rust_maybe_catch_panic
             at src/libpanic_unwind/lib.rs:86
  22: std::panicking::try
             at src/libstd/panicking.rs:281
  23: std::panic::catch_unwind
             at src/libstd/panic.rs:394
  24: std::rt::lang_start_internal
             at src/libstd/rt.rs:51
  25: std::rt::lang_start
             at /rustc/b08d07143d2b61777d341f8658281adc0f2ac809/src/libstd/rt.rs:67
  26: navi::main
```