### PR TITLE
Standard Config Directories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,6 +17,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayref"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "arrayvec"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -27,8 +37,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "base64"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "blake2b_simd"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "arrayref 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "constant_time_eq 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "cfg-if"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -46,6 +81,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -54,6 +104,36 @@ dependencies = [
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "dirs"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dirs-sys 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_users 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasi 0.9.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -91,6 +171,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "navi"
 version = "2.0.7"
 dependencies = [
+ "dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "raw_tty 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -183,6 +264,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rust-argon2 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "regex"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -197,6 +288,17 @@ dependencies = [
 name = "regex-syntax"
 version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rust-argon2"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "blake2b_simd 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "constant_time_eq 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "rustc_version"
@@ -348,6 +450,11 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "winapi"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -369,10 +476,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [metadata]
 "checksum aho-corasick 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)" = "743ad5a418686aad3b87fd14c43badd828cf26e214a00f92a384291cf22e1811"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+"checksum arrayref 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
+"checksum arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
 "checksum atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+"checksum autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
+"checksum base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+"checksum blake2b_simd 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)" = "d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a"
+"checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
+"checksum constant_time_eq 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+"checksum crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 "checksum derive_more 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6d944ac6003ed268757ef1ee686753b57efc5fcf0ebe7b64c9fc81e7e32ff839"
+"checksum dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
+"checksum dirs-sys 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "afa0b23de8fd801745c471deffa6e12d248f962c9fd4b4c33787b055599bde7b"
+"checksum getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum hermit-abi 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1010591b26bbfe835e9faeabeb11866061cc7dcebffd56ad7d0942d0e61aefd8"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
@@ -388,8 +506,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum raw_tty 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "51f512d7504049ef0d3f5d48d8aa5129beaea4fccfaf5c500c9b60101394f8b1"
 "checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
+"checksum redox_users 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "09b23093265f8d200fa7b4c2c76297f47e681c655f6f1285a8780d6a022f7431"
 "checksum regex 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "322cf97724bea3ee221b78fe25ac9c46114ebb51747ad5babd51a2fc6a8235a8"
 "checksum regex-syntax 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)" = "b28dfe3fe9badec5dbf0a79a9cccad2cfc2ab5484bdb3e44cbd1ae8b3ba2be06"
+"checksum rust-argon2 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2bc8af4bda8e1ff4932523b94d3dd20ee30a87232323eda55903ffd71d2fb017"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum rustversion 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b3bba175698996010c4f6dce5e7f173b6eb781fce25d2cfc45e27091ce0b79f6"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
@@ -409,6 +529,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
+"checksum wasi 0.9.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)" = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 "checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+dirs = "2.0"
 regex = "1.3.4"
 structopt = "0.3"
 termion = "1.5.5"

--- a/src/cheat.rs
+++ b/src/cheat.rs
@@ -136,9 +136,11 @@ pub fn read_all(config: &Config, stdin: &mut std::process::ChildStdin) -> HashMa
 
     let fallback = filesystem::pathbuf_to_string(filesystem::cheat_pathbuf().unwrap_or("".into()));
     let folders_str = config.path.as_ref().unwrap_or(&fallback);
-    let mut folders: Vec<&str> = folders_str.split(':').collect();
+    let mut folders: Vec<String> = folders_str.split(':').map(|s| s.into()).collect();
     if !config.no_bundled_cheats {
-        folders.push(filesystem::BUNDLED_CHEAT_DIR);
+        if let Some(bundled_dir) = filesystem::bundled_cheat_pathbuf() {
+            folders.push(filesystem::pathbuf_to_string(bundled_dir));
+        }
     }
 
     for folder in folders {

--- a/src/cheat.rs
+++ b/src/cheat.rs
@@ -134,9 +134,12 @@ fn read_file(
 pub fn read_all(config: &Config, stdin: &mut std::process::ChildStdin) -> HashMap<String, Value> {
     let mut variables: HashMap<String, Value> = HashMap::new();
 
-    let fallback = filesystem::pathbuf_to_string(filesystem::cheat_pathbuf().unwrap());
+    let fallback = filesystem::pathbuf_to_string(filesystem::cheat_pathbuf().unwrap_or("".into()));
     let folders_str = config.path.as_ref().unwrap_or(&fallback);
-    let folders = folders_str.split(':');
+    let mut folders: Vec<&str> = folders_str.split(':').collect();
+    if !config.no_bundled_cheats {
+        folders.push(filesystem::BUNDLED_CHEAT_DIR);
+    }
 
     for folder in folders {
         if let Ok(paths) = fs::read_dir(folder) {

--- a/src/cmds/shell.rs
+++ b/src/cmds/shell.rs
@@ -9,11 +9,7 @@ pub fn main(shell: &str) -> Result<(), Box<dyn Error>> {
         _ => "navi.plugin.bash",
     };
 
-    println!(
-        "{}/{}",
-        filesystem::pathbuf_to_string(filesystem::shell_pathbuf()),
-        file
-    );
+    println!("{}/{}", filesystem::SHELL_PLUGIN_DIR, file);
 
     Ok(())
 }

--- a/src/cmds/shell.rs
+++ b/src/cmds/shell.rs
@@ -9,7 +9,11 @@ pub fn main(shell: &str) -> Result<(), Box<dyn Error>> {
         _ => "navi.plugin.bash",
     };
 
-    println!("{}/{}", filesystem::SHELL_PLUGIN_DIR, file);
+    println!(
+        "{}/{}",
+        filesystem::pathbuf_to_string(filesystem::shell_pathbuf().unwrap()),
+        file
+    );
 
     Ok(())
 }

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -4,9 +4,6 @@ use std::fs::File;
 use std::io::{self, BufRead, BufReader, Lines};
 use std::path::{Path, PathBuf};
 
-pub const BUNDLED_CHEAT_DIR: &'static str = "/usr/share/navi/cheats";
-pub const SHELL_PLUGIN_DIR: &'static str = "/usr/share/navi/shell";
-
 pub fn read_lines<P>(filename: P) -> io::Result<Lines<BufReader<File>>>
 where
     P: AsRef<Path>,
@@ -41,6 +38,28 @@ pub fn cheat_pathbuf() -> Option<PathBuf> {
     match dirs::config_dir() {
         Some(mut d) => {
             d.push("navi");
+            Some(d)
+        }
+        None => None,
+    }
+}
+
+pub fn bundled_cheat_pathbuf() -> Option<PathBuf> {
+    match dirs::data_dir() {
+        Some(mut d) => {
+            d.push("navi");
+            d.push("cheats");
+            Some(d)
+        }
+        None => None,
+    }
+}
+
+pub fn shell_pathbuf() -> Option<PathBuf> {
+    match dirs::data_dir() {
+        Some(mut d) => {
+            d.push("navi");
+            d.push("shell");
             Some(d)
         }
         None => None,

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -1,8 +1,11 @@
+use dirs;
 use std::fs;
-use std::fs::metadata;
 use std::fs::File;
 use std::io::{self, BufRead, BufReader, Lines};
 use std::path::{Path, PathBuf};
+
+pub const BUNDLED_CHEAT_DIR: &'static str = "/usr/share/navi/cheats";
+pub const SHELL_PLUGIN_DIR: &'static str = "/usr/share/navi/shell";
 
 pub fn read_lines<P>(filename: P) -> io::Result<Lines<BufReader<File>>>
 where
@@ -34,31 +37,19 @@ fn follow_symlink(pathbuf: PathBuf) -> PathBuf {
     }
 }
 
+pub fn cheat_pathbuf() -> Option<PathBuf> {
+    match dirs::config_dir() {
+        Some(mut d) => {
+            d.push("navi");
+            Some(d)
+        }
+        None => None,
+    }
+}
+
 fn exe_pathbuf() -> PathBuf {
     let pathbuf = std::env::current_exe().unwrap();
     follow_symlink(pathbuf)
-}
-
-pub fn cheat_pathbuf() -> Option<PathBuf> {
-    let exe_parent_str = exe_parent_string();
-
-    let array = ["cheats", "../libexec/cheats", "../cheats", "../../cheats"];
-    for elem in &array {
-        let p = format!("{}/{}", exe_parent_str, elem);
-        let meta = metadata(&p);
-        if let Ok(m) = meta {
-            if m.is_dir() {
-                return Some(PathBuf::from(p));
-            }
-        }
-    }
-
-    None
-}
-
-pub fn shell_pathbuf() -> PathBuf {
-    let cheat_path_str = pathbuf_to_string(cheat_pathbuf().unwrap());
-    PathBuf::from(format!("{}/../shell", cheat_path_str))
 }
 
 pub fn exe_string() -> String {

--- a/src/option.rs
+++ b/src/option.rs
@@ -30,6 +30,10 @@ pub struct Config {
     #[structopt(long)]
     pub no_autoselect: bool,
 
+    /// Prevents the bundled cheats from being loaded
+    #[structopt(long)]
+    pub no_bundled_cheats: bool,
+
     /// Hides preview window
     #[structopt(long)]
     pub no_preview: bool,


### PR DESCRIPTION
First go at adding #233 (Would be cleaner if #237 was implemented)

This is my first rust PR so I'm very open to constructive criticism!

This is an attempt to get `navi` loading config from "standard" config directories. I've split the bundled cheats out into their own folder at the system level and set the fallback cheat path to the user's `XDG_CONFIG_HOME`. I run Linux so haven't been able to test with OSX. It would probably need either some changes in the code or in the `brew` install process to get it working there.