### PR TITLE
cargo: remove openssl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,11 +21,9 @@ dirs = "2.0.0"
 terminal_size = "0.1.10"
 git2 = "0.10.0"
 walkdir = "2"
-openssl = { version = '0.10', optional = true }
 
 [features]
 default = []
-vendored-openssl = ["openssl/vendored"]
 
 [[bin]]
 bench = false


### PR DESCRIPTION
I couldn't figure out why this dependency is in the Cargo.toml.
OpenSSL is never used in `/src/`. So I deleted it.