### PR TITLE
Improve error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,7 +250,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "navi"
-version = "2.3.1"
+version = "2.4.0"
 dependencies = [
  "anyhow 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,6 +262,7 @@ dependencies = [
  "structopt 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "terminal_size 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "termion 1.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -550,6 +551,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "thiserror-impl 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "thread_local"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -726,6 +745,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum terminal_size 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "e25a60e3024df9029a414be05f46318a77c22538861a22170077d0388c0e926e"
 "checksum termion 1.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "c22cec9d8978d906be5ac94bceb5a010d885c626c4c8855721a4dbd20e3ac905"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+"checksum thiserror 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)" = "268c0f167625b8b0cc90a91787b158a372b4edadb31d6e20479dc787309defad"
+"checksum thiserror-impl 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)" = "9a3ecbaa927a1d5a73d14a20af52463fa433c0727d07ef5e208f0546841d2efd"
 "checksum thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
 "checksum unicode-normalization 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "5479532badd04e128284890390c1e876ef7a993d0570b3597ae43dfa1d59afa4"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,6 +17,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "arrayref"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -247,6 +252,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "navi"
 version = "2.3.0"
 dependencies = [
+ "anyhow 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "git2 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -657,6 +663,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [metadata]
 "checksum aho-corasick 0.7.10 (registry+https://github.com/rust-lang/crates.io-index)" = "8716408b8bc624ed7f65d223ddb9ac2d044c0547b6fa4b0d554f3a9540496ada"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+"checksum anyhow 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)" = "013a6e0a2cbe3d20f9c60b65458f7a7f7a5e636c5d0f45a5a6aee5d4b1f01785"
 "checksum arrayref 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
 "checksum arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
 "checksum atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ terminal_size = "0.1.10"
 walkdir = "2"
 shellwords = "1.0.0"
 anyhow = "1.0.27"
+thiserror = "1.0.12"
 
 [dependencies.git2]
 version = "0.10.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "navi"
-version = "2.3.1"
+version = "2.4.0"
 authors = ["Denis Isidoro <denis_isidoro@live.com>"]
 edition = "2018"
 description = "An interactive cheatsheet tool for the command-line"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ dirs = "2.0.0"
 terminal_size = "0.1.10"
 walkdir = "2"
 shellwords = "1.0.0"
+anyhow = "1.0.27"
 
 [dependencies.git2]
 version = "0.10.0"

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,7 +1,5 @@
 extern crate navi;
 
-use navi::FileAnIssue;
-
-fn main() -> Result<(), FileAnIssue> {
-    navi::handle_config(navi::config_from_env()).map_err(FileAnIssue::new)
+fn main() -> Result<(), anyhow::Error> {
+    navi::handle_config(navi::config_from_env()).map_err(|e| navi::FileAnIssue::new(e).into())
 }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,7 +1,7 @@
 extern crate navi;
 
-use std::error::Error;
+use anyhow::Error;
 
-fn main() -> Result<(), Box<dyn Error>> {
+fn main() -> Result<(), Error> {
     navi::handle_config(navi::config_from_env())
 }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,7 +1,7 @@
 extern crate navi;
 
-use anyhow::Error;
+use navi::FileAnIssue;
 
-fn main() -> Result<(), Error> {
-    navi::handle_config(navi::config_from_env())
+fn main() -> Result<(), FileAnIssue> {
+    navi::handle_config(navi::config_from_env()).map_err(FileAnIssue::new)
 }

--- a/src/display.rs
+++ b/src/display.rs
@@ -13,7 +13,7 @@ pub const DELIMITER: &str = r"  ⠀";
 
 lazy_static! {
     pub static ref WIDTHS: (usize, usize) = get_widths();
-    pub static ref NEWLINE_REGEX: Regex = Regex::new(r"\\\s+").unwrap();
+    pub static ref NEWLINE_REGEX: Regex = Regex::new(r"\\\s+").expect("Invalid regex");
 }
 
 fn get_widths() -> (usize, usize) {

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -1,4 +1,5 @@
 use crate::structures::error::filesystem::InvalidPath;
+use crate::structures::error::filesystem::UnreadableDir;
 use crate::structures::option::Config;
 use anyhow::Context;
 use anyhow::Error;
@@ -78,13 +79,13 @@ fn cheat_paths_from_config_dir() -> Result<String, Error> {
         .and_then(pathbuf_to_string)
         .and_then(|path| {
             fs::read_dir(path.clone())
-                .with_context(|| format!("Unable to read directory `{}`", &path))
+                .map_err(|e| UnreadableDir::new(path.clone(), e).into())
                 .map(|entries| (path, entries))
         })
         .and_then(|(path, dir_entries)| {
             let mut paths_str = String::from("");
             for entry in dir_entries {
-                let path = entry.with_context(|| format!("Unable to read directory `{}`", path))?;
+                let path = entry.map_err(|e| UnreadableDir::new(path.clone(), e))?;
                 paths_str.push_str(
                     path.path()
                         .into_os_string()

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -1,17 +1,23 @@
 use crate::structures::option::Config;
 use anyhow::Context;
 use anyhow::Error;
+use core::fmt::Display;
 use std::fs;
 use std::fs::File;
-use std::io::{self, BufRead, BufReader, Lines};
+use std::io::{self, BufRead};
 use std::path::{Path, PathBuf};
 
-pub fn read_lines<P>(filename: P) -> io::Result<Lines<BufReader<File>>>
+pub fn read_lines<P>(filename: P) -> Result<Vec<String>, Error>
 where
-    P: AsRef<Path>,
+    P: AsRef<Path> + Display,
 {
+    let error_string = format!("Failed to read lines from {}", filename);
     let file = File::open(filename)?;
-    Ok(io::BufReader::new(file).lines())
+    io::BufReader::new(file)
+        .lines()
+        .map(|line| line.map_err(Error::from))
+        .collect::<Result<Vec<String>, Error>>()
+        .with_context(|| error_string)
 }
 
 pub fn pathbuf_to_string(pathbuf: PathBuf) -> Result<String, Error> {

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -67,11 +67,16 @@ pub fn exe_string() -> Result<String, Error> {
 
 fn cheat_paths_from_config_dir() -> Result<String, Error> {
     cheat_pathbuf()
-        .and_then(|f| fs::read_dir(pathbuf_to_string(f)?).context("Unable to read directory"))
-        .and_then(|dir_entries| {
+        .and_then(pathbuf_to_string)
+        .and_then(|path| {
+            fs::read_dir(path.clone())
+                .with_context(|| format!("Unable to read directory {}", &path))
+                .map(|entries| (path, entries))
+        })
+        .and_then(|(path, dir_entries)| {
             let mut paths_str = String::from("");
             for entry in dir_entries {
-                let path = entry.context("Unable to read directory")?;
+                let path = entry.with_context(|| format!("Unable to read directory {}", path))?;
                 paths_str.push_str(
                     path.path()
                         .into_os_string()

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -11,7 +11,7 @@ pub fn read_lines<P>(filename: P) -> Result<Vec<String>, Error>
 where
     P: AsRef<Path> + Display,
 {
-    let error_string = format!("Failed to read lines from {}", filename);
+    let error_string = format!("Failed to read lines from `{}`", filename);
     let file = File::open(filename)?;
     io::BufReader::new(file)
         .lines()
@@ -24,7 +24,7 @@ pub fn pathbuf_to_string(pathbuf: PathBuf) -> Result<String, Error> {
     pathbuf
         .as_os_str()
         .to_str()
-        .ok_or_else(|| anyhow!("Invalid path {}", pathbuf.display()))
+        .ok_or_else(|| anyhow!("Invalid path `{}`", pathbuf.display()))
         .map(str::to_string)
 }
 
@@ -44,14 +44,16 @@ fn follow_symlink(pathbuf: PathBuf) -> Result<PathBuf, Error> {
             let o_str = o
                 .as_os_str()
                 .to_str()
-                .ok_or_else(|| anyhow!("Invalid path {}", o.display()))?;
+                .ok_or_else(|| anyhow!("Invalid path `{}`", o.display()))?;
             if o_str.starts_with('.') {
                 let parent_str = pathbuf
                     .parent()
-                    .ok_or_else(|| anyhow!("{} has no parent", pathbuf.display()))?
+                    .ok_or_else(|| anyhow!("`{}` has no parent", pathbuf.display()))?
                     .as_os_str()
                     .to_str()
-                    .ok_or_else(|| anyhow!("Parent of {} is an invalid path", pathbuf.display()))?;
+                    .ok_or_else(|| {
+                        anyhow!("Parent of `{}` is an invalid path", pathbuf.display())
+                    })?;
                 let path_str = format!("{}/{}", parent_str, o_str);
                 let p = PathBuf::from(path_str);
                 follow_symlink(p)
@@ -76,18 +78,18 @@ fn cheat_paths_from_config_dir() -> Result<String, Error> {
         .and_then(pathbuf_to_string)
         .and_then(|path| {
             fs::read_dir(path.clone())
-                .with_context(|| format!("Unable to read directory {}", &path))
+                .with_context(|| format!("Unable to read directory `{}`", &path))
                 .map(|entries| (path, entries))
         })
         .and_then(|(path, dir_entries)| {
             let mut paths_str = String::from("");
             for entry in dir_entries {
-                let path = entry.with_context(|| format!("Unable to read directory {}", path))?;
+                let path = entry.with_context(|| format!("Unable to read directory `{}`", path))?;
                 paths_str.push_str(
                     path.path()
                         .into_os_string()
                         .to_str()
-                        .ok_or_else(|| anyhow!("Invalid path {}", path.path().display()))?,
+                        .ok_or_else(|| anyhow!("Invalid path `{}`", path.path().display()))?,
                 );
                 paths_str.push_str(":");
             }
@@ -104,11 +106,11 @@ pub fn cheat_paths(config: &Config) -> Result<String, Error> {
 }
 
 pub fn create_dir(path: &str) -> Result<(), Error> {
-    fs::create_dir_all(path).with_context(|| format!("Failed to create directory {}", path))
+    fs::create_dir_all(path).with_context(|| format!("Failed to create directory `{}`", path))
 }
 
 pub fn remove_dir(path: &str) -> Result<(), Error> {
-    fs::remove_dir_all(path).with_context(|| format!("Failed to remove directory {}", path))
+    fs::remove_dir_all(path).with_context(|| format!("Failed to remove directory `{}`", path))
 }
 
 pub fn tmp_path_str() -> Result<String, Error> {

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -1,4 +1,4 @@
-use crate::structures::error::FilesystemError;
+use crate::structures::error::filesystem::InvalidPath;
 use crate::structures::option::Config;
 use anyhow::Context;
 use anyhow::Error;
@@ -25,7 +25,7 @@ pub fn pathbuf_to_string(pathbuf: PathBuf) -> Result<String, Error> {
     Ok(pathbuf
         .as_os_str()
         .to_str()
-        .ok_or_else(|| FilesystemError::InvalidPath(pathbuf.to_path_buf()))
+        .ok_or_else(|| InvalidPath(pathbuf.to_path_buf()))
         .map(str::to_string)?)
 }
 
@@ -45,7 +45,7 @@ fn follow_symlink(pathbuf: PathBuf) -> Result<PathBuf, Error> {
             let o_str = o
                 .as_os_str()
                 .to_str()
-                .ok_or_else(|| FilesystemError::InvalidPath(o.to_path_buf()))?;
+                .ok_or_else(|| InvalidPath(o.to_path_buf()))?;
             if o_str.starts_with('.') {
                 let parent = pathbuf
                     .parent()
@@ -53,7 +53,7 @@ fn follow_symlink(pathbuf: PathBuf) -> Result<PathBuf, Error> {
                 let parent_str = parent
                     .as_os_str()
                     .to_str()
-                    .ok_or_else(|| FilesystemError::InvalidPath(parent.to_path_buf()))?;
+                    .ok_or_else(|| InvalidPath(parent.to_path_buf()))?;
                 let path_str = format!("{}/{}", parent_str, o_str);
                 let p = PathBuf::from(path_str);
                 follow_symlink(p)
@@ -89,7 +89,7 @@ fn cheat_paths_from_config_dir() -> Result<String, Error> {
                     path.path()
                         .into_os_string()
                         .to_str()
-                        .ok_or_else(|| FilesystemError::InvalidPath(path.path()))?,
+                        .ok_or_else(|| InvalidPath(path.path()))?,
                 );
                 paths_str.push_str(":");
             }

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -102,7 +102,9 @@ pub fn cheat_paths(config: &Config) -> Result<String, Error> {
         .path
         .clone()
         .ok_or_else(|| anyhow!("No cheat paths"))
-        .or_else(|_| cheat_paths_from_config_dir().context("No cheat paths from config directory"))
+        .or_else(|_| {
+            cheat_paths_from_config_dir().context("No directory for cheats in user data directory")
+        })
 }
 
 pub fn create_dir(path: &str) -> Result<(), Error> {

--- a/src/flows/aux.rs
+++ b/src/flows/aux.rs
@@ -1,7 +1,7 @@
-use std::error::Error;
+use anyhow::Error;
 use std::process;
 
-pub fn abort(operation: &str, issue_number: u32) -> Result<(), Box<dyn Error>> {
+pub fn abort(operation: &str, issue_number: u32) -> Result<(), Error> {
     eprintln!("This version of navi doesn't support {}.", operation);
     eprintln!(
         "Please check https://github.com/denisidoro/navi/issues/{} for more info.",

--- a/src/flows/best.rs
+++ b/src/flows/best.rs
@@ -1,9 +1,9 @@
 use crate::flows;
 use crate::flows::core::Variant;
 use crate::structures::option::Config;
-use std::error::Error;
+use anyhow::Error;
 
-pub fn main(query: String, args: Vec<String>, config: Config) -> Result<(), Box<dyn Error>> {
+pub fn main(query: String, args: Vec<String>, config: Config) -> Result<(), Error> {
     if args.is_empty() {
         flows::core::main(Variant::Filter(query), config, false)
     } else {

--- a/src/flows/core.rs
+++ b/src/flows/core.rs
@@ -15,6 +15,10 @@ use std::fs;
 use std::io::Write;
 use std::process::{Command, Stdio};
 
+lazy_static! {
+    pub static ref VAR_REGEX: Regex = Regex::new(r"<(\w[\w\d\-_]*)>").expect("Invalid regex");
+}
+
 pub enum Variant {
     Core,
     Filter(String),
@@ -123,8 +127,7 @@ fn replace_variables_from_snippet(
     let mut interpolated_snippet = String::from(snippet);
     let mut values: HashMap<String, String> = HashMap::new();
 
-    let re = Regex::new(r"<(\w[\w\d\-_]*)>").unwrap();
-    for captures in re.captures_iter(snippet) {
+    for captures in VAR_REGEX.captures_iter(snippet) {
         let bracketed_variable_name = &captures[0];
         let variable_name = &bracketed_variable_name[1..bracketed_variable_name.len() - 1];
 

--- a/src/flows/core.rs
+++ b/src/flows/core.rs
@@ -148,7 +148,7 @@ fn replace_variables_from_snippet(
         let value = values
             .get(variable_name)
             .map(|s| s.to_string())
-            .ok_or_else(|| anyhow!(format!("No value for variable {}", variable_name)))
+            .ok_or_else(|| anyhow!(format!("No value for variable `{}`", variable_name)))
             .or_else(|_| {
                 variables
                     .get(&tags, &variable_name)

--- a/src/flows/func.rs
+++ b/src/flows/func.rs
@@ -1,18 +1,22 @@
 use crate::handler;
 use crate::structures::option;
-use std::error::Error;
+use anyhow::Context;
+use anyhow::Error;
 use std::process::Command;
 
-pub fn main(func: String, args: Vec<String>) -> Result<(), Box<dyn Error>> {
+pub fn main(func: String, args: Vec<String>) -> Result<(), Error> {
     match func.as_str() {
         "url::open" => {
-            let url = args.into_iter().next().unwrap();
+            let url = args
+                .into_iter()
+                .next()
+                .ok_or_else(|| anyhow!("No URL specified"))?;
             let cmd = format!("url=\"{}\"; (xdg-open \"$url\" 2> /dev/null || open \"$url\" 2> /dev/null) &disown", url);
             Command::new("bash")
                 .arg("-c")
                 .arg(cmd.as_str())
                 .spawn()
-                .unwrap();
+                .context("Failed to spawn bash instance")?;
             Ok(())
         }
 
@@ -20,6 +24,6 @@ pub fn main(func: String, args: Vec<String>) -> Result<(), Box<dyn Error>> {
             "navi --path /tmp/irrelevant".split(' ').collect(),
         )),
 
-        _ => unreachable!(""),
+        _ => Err(anyhow!("Unrecognized function")),
     }
 }

--- a/src/flows/func.rs
+++ b/src/flows/func.rs
@@ -16,7 +16,7 @@ pub fn main(func: String, args: Vec<String>) -> Result<(), Error> {
                 .arg("-c")
                 .arg(cmd.as_str())
                 .spawn()
-                .context("Failed to spawn bash instance")?;
+                .context("Failed to execute bash")?;
             Ok(())
         }
 

--- a/src/flows/func.rs
+++ b/src/flows/func.rs
@@ -1,6 +1,5 @@
 use crate::handler;
-use crate::structures::option;
-use anyhow::Context;
+use crate::structures::{error::command::BashSpawnError, option};
 use anyhow::Error;
 use std::process::Command;
 
@@ -16,7 +15,7 @@ pub fn main(func: String, args: Vec<String>) -> Result<(), Error> {
                 .arg("-c")
                 .arg(cmd.as_str())
                 .spawn()
-                .context("Failed to execute bash")?;
+                .map_err(|e| BashSpawnError::new(cmd, e))?;
             Ok(())
         }
 

--- a/src/flows/preview.rs
+++ b/src/flows/preview.rs
@@ -1,16 +1,16 @@
 use crate::display;
-use std::error::Error;
+use anyhow::Error;
 use std::process;
 
 fn extract_elements(argstr: &str) -> (&str, &str, &str) {
     let mut parts = argstr.split(display::DELIMITER).skip(3);
-    let tags = parts.next().unwrap();
-    let comment = parts.next().unwrap();
-    let snippet = parts.next().unwrap();
+    let tags = parts.next().expect("No `tags` element provided.");
+    let comment = parts.next().expect("No `comment` element provided.");
+    let snippet = parts.next().expect("No `snippet` element provided.");
     (tags, comment, snippet)
 }
 
-pub fn main(line: &str) -> Result<(), Box<dyn Error>> {
+pub fn main(line: &str) -> Result<(), Error> {
     let (tags, comment, snippet) = extract_elements(line);
     display::preview(comment, tags, snippet);
     process::exit(0)

--- a/src/flows/query.rs
+++ b/src/flows/query.rs
@@ -1,8 +1,8 @@
 use crate::flows;
 use crate::flows::core::Variant;
 use crate::structures::option::Config;
-use std::error::Error;
+use anyhow::Error;
 
-pub fn main(query: String, config: Config) -> Result<(), Box<dyn Error>> {
+pub fn main(query: String, config: Config) -> Result<(), Error> {
     flows::core::main(Variant::Query(query), config, true)
 }

--- a/src/flows/repo.rs
+++ b/src/flows/repo.rs
@@ -91,7 +91,7 @@ pub fn add(uri: String) -> Result<(), Error> {
         let filename = f.replace("./", "").replace("/", "__");
         let to = format!("{}/{}", to_folder, filename);
         fs::create_dir_all(to_folder).unwrap_or(());
-        fs::copy(from, to)?;
+        fs::copy(&from, &to).with_context(|| format!("Failed to copy `{}` to `{}`", from, to))?;
     }
 
     filesystem::remove_dir(&tmp_path_str)?;

--- a/src/flows/repo.rs
+++ b/src/flows/repo.rs
@@ -30,9 +30,10 @@ pub fn browse() -> Result<(), Error> {
     let (repo, _) = fzf::call(opts, |stdin| {
         stdin
             .write_all(repos.as_bytes())
-            .expect("Unable to prompt featured repositories");
-        None
-    });
+            .context("Unable to prompt featured repositories")?;
+        Ok(None)
+    })
+    .context("Failed to get repo URL from fzf")?;
 
     filesystem::remove_dir(&repo_path_str)?;
 
@@ -76,9 +77,10 @@ pub fn add(uri: String) -> Result<(), Error> {
     let (files, _) = fzf::call(opts, |stdin| {
         stdin
             .write_all(all_files.as_bytes())
-            .expect("Unable to prompt cheats to import");
-        None
-    });
+            .context("Unable to prompt cheats to import")?;
+        Ok(None)
+    })
+    .context("Failed to get cheatsheet files from fzf")?;
 
     for f in files.split('\n') {
         let from = format!("{}/{}", tmp_path_str, f).replace("./", "");

--- a/src/flows/repo.rs
+++ b/src/flows/repo.rs
@@ -12,7 +12,10 @@ use walkdir::WalkDir;
 pub fn browse() -> Result<(), Error> {
     let repo_path_str = format!("{}/featured", filesystem::tmp_path_str()?);
 
-    filesystem::remove_dir(&repo_path_str)?;
+    // The dir might not exist which would throw an error. But here we don't care about that
+    // since our purpose is to make space for a new directory. Potential other errors
+    // (e.g due to lack of permission) will cause an error during dir creation.
+    let _ = filesystem::remove_dir(&repo_path_str);
     filesystem::create_dir(&repo_path_str)?;
 
     let repo_url = "https://github.com/denisidoro/cheats";

--- a/src/flows/repo.rs
+++ b/src/flows/repo.rs
@@ -3,13 +3,13 @@ use crate::fzf;
 use crate::git;
 use crate::structures::fzf::{Opts as FzfOpts, SuggestionType};
 use anyhow::Context;
+use anyhow::Error;
 use git2::Repository;
-use std::error::Error;
 use std::fs;
 use std::io::Write;
 use walkdir::WalkDir;
 
-pub fn browse() -> Result<(), Box<dyn Error>> {
+pub fn browse() -> Result<(), Error> {
     let repo_path_str = format!("{}/featured", filesystem::tmp_path_str());
 
     filesystem::remove_dir(&repo_path_str);
@@ -17,10 +17,10 @@ pub fn browse() -> Result<(), Box<dyn Error>> {
 
     let repo_url = "https://github.com/denisidoro/cheats";
     Repository::clone(repo_url, &repo_path_str)
-        .with_context(|| format!("Failed to clone {}.", repo_url))?;
+        .with_context(|| format!("Failed to clone {}", repo_url))?;
 
     let repos = fs::read_to_string(format!("{}/featured_repos.txt", &repo_path_str))
-        .context("Unable to fetch featured repos.")?;
+        .context("Unable to fetch featured repositories")?;
 
     let opts = FzfOpts {
         column: Some(1),
@@ -30,7 +30,7 @@ pub fn browse() -> Result<(), Box<dyn Error>> {
     let (repo, _) = fzf::call(opts, |stdin| {
         stdin
             .write_all(repos.as_bytes())
-            .expect("Unable to prompt featured repos.");
+            .expect("Unable to prompt featured repositories");
         None
     });
 
@@ -39,10 +39,10 @@ pub fn browse() -> Result<(), Box<dyn Error>> {
     add(repo)
 }
 
-pub fn add(uri: String) -> Result<(), Box<dyn Error>> {
+pub fn add(uri: String) -> Result<(), Error> {
     let (actual_uri, user, repo) = git::meta(uri.as_str());
 
-    let cheat_path_str = filesystem::pathbuf_to_string(filesystem::cheat_pathbuf().unwrap());
+    let cheat_path_str = filesystem::pathbuf_to_string(filesystem::cheat_pathbuf()?);
     let tmp_path_str = filesystem::tmp_path_str();
     let tmp_path_str_with_trailing_slash = format!("{}/", &tmp_path_str);
 
@@ -51,10 +51,8 @@ pub fn add(uri: String) -> Result<(), Box<dyn Error>> {
 
     eprintln!("Cloning {} into {}...\n", &actual_uri, &tmp_path_str);
 
-    match Repository::clone(actual_uri.as_str(), &tmp_path_str) {
-        Ok(r) => r,
-        Err(e) => panic!("failed to clone: {}", e),
-    };
+    Repository::clone(actual_uri.as_str(), &tmp_path_str)
+        .with_context(|| format!("Failed to clone {}", actual_uri))?;
 
     let all_files = WalkDir::new(&tmp_path_str)
         .into_iter()

--- a/src/flows/repo.rs
+++ b/src/flows/repo.rs
@@ -17,7 +17,7 @@ pub fn browse() -> Result<(), Error> {
 
     let repo_url = "https://github.com/denisidoro/cheats";
     Repository::clone(repo_url, &repo_path_str)
-        .with_context(|| format!("Failed to clone {}", repo_url))?;
+        .with_context(|| format!("Failed to clone `{}`", repo_url))?;
 
     let repos = fs::read_to_string(format!("{}/featured_repos.txt", &repo_path_str))
         .context("Unable to fetch featured repositories")?;
@@ -53,7 +53,7 @@ pub fn add(uri: String) -> Result<(), Error> {
     eprintln!("Cloning {} into {}...\n", &actual_uri, &tmp_path_str);
 
     Repository::clone(actual_uri.as_str(), &tmp_path_str)
-        .with_context(|| format!("Failed to clone {}", actual_uri))?;
+        .with_context(|| format!("Failed to clone `{}`", actual_uri))?;
 
     let all_files = WalkDir::new(&tmp_path_str)
         .into_iter()

--- a/src/flows/repo.rs
+++ b/src/flows/repo.rs
@@ -10,10 +10,10 @@ use std::io::Write;
 use walkdir::WalkDir;
 
 pub fn browse() -> Result<(), Error> {
-    let repo_path_str = format!("{}/featured", filesystem::tmp_path_str());
+    let repo_path_str = format!("{}/featured", filesystem::tmp_path_str()?);
 
-    filesystem::remove_dir(&repo_path_str);
-    filesystem::create_dir(&repo_path_str);
+    filesystem::remove_dir(&repo_path_str)?;
+    filesystem::create_dir(&repo_path_str)?;
 
     let repo_url = "https://github.com/denisidoro/cheats";
     Repository::clone(repo_url, &repo_path_str)
@@ -34,7 +34,7 @@ pub fn browse() -> Result<(), Error> {
         None
     });
 
-    filesystem::remove_dir(&repo_path_str);
+    filesystem::remove_dir(&repo_path_str)?;
 
     add(repo)
 }
@@ -42,12 +42,12 @@ pub fn browse() -> Result<(), Error> {
 pub fn add(uri: String) -> Result<(), Error> {
     let (actual_uri, user, repo) = git::meta(uri.as_str());
 
-    let cheat_path_str = filesystem::pathbuf_to_string(filesystem::cheat_pathbuf()?);
-    let tmp_path_str = filesystem::tmp_path_str();
+    let cheat_path_str = filesystem::pathbuf_to_string(filesystem::cheat_pathbuf()?)?;
+    let tmp_path_str = filesystem::tmp_path_str()?;
     let tmp_path_str_with_trailing_slash = format!("{}/", &tmp_path_str);
 
-    filesystem::remove_dir(&tmp_path_str);
-    filesystem::create_dir(&tmp_path_str);
+    filesystem::remove_dir(&tmp_path_str)?;
+    filesystem::create_dir(&tmp_path_str)?;
 
     eprintln!("Cloning {} into {}...\n", &actual_uri, &tmp_path_str);
 
@@ -89,7 +89,7 @@ pub fn add(uri: String) -> Result<(), Error> {
         fs::copy(from, to)?;
     }
 
-    filesystem::remove_dir(&tmp_path_str);
+    filesystem::remove_dir(&tmp_path_str)?;
 
     eprintln!("The following .cheat files were imported successfully:\n{}\n\nThey are now located at {}\n\nPlease run navi again to check the results.", files, cheat_path_str);
 

--- a/src/flows/search.rs
+++ b/src/flows/search.rs
@@ -1,7 +1,7 @@
 use super::aux;
 use crate::structures::option::Config;
-use std::error::Error;
+use anyhow::Error;
 
-pub fn main(_query: String, _config: Config) -> Result<(), Box<dyn Error>> {
+pub fn main(_query: String, _config: Config) -> Result<(), Error> {
     aux::abort("searching for cheats online", 201)
 }

--- a/src/flows/shell.rs
+++ b/src/flows/shell.rs
@@ -1,6 +1,6 @@
-use std::error::Error;
+use anyhow::Error;
 
-pub fn main(shell: &str) -> Result<(), Box<dyn Error>> {
+pub fn main(shell: &str) -> Result<(), Error> {
     let content = match shell {
         "zsh" => include_str!("../../shell/navi.plugin.zsh"),
         "fish" => include_str!("../../shell/navi.plugin.fish"),

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -13,13 +13,16 @@ pub fn handle_config(config: Config) -> Result<(), Error> {
             Preview { line } => flows::preview::main(&line[..]),
 
             Query { query } => {
-                let error_string = format!("Failed to filter cheatsheets for {}", &query);
-                flows::query::main(query.clone(), config).context(error_string)
+                let query_clone = query.clone();
+                flows::query::main(query.clone(), config)
+                    .with_context(|| format!("Failed to filter cheatsheets for {}", query_clone))
             }
 
             Best { query, args } => {
-                let error_string = format!("Failed to execute snippet similar to {}", &query);
-                flows::best::main(query.clone(), args.to_vec(), config).context(error_string)
+                let query_clone = query.clone();
+                flows::best::main(query.clone(), args.to_vec(), config).with_context(|| {
+                    format!("Failed to execute snippet similar to {}", query_clone)
+                })
             }
 
             Search { query } => flows::search::main(query.clone(), config)

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -28,11 +28,11 @@ pub fn handle_config(mut config: Config) -> Result<(), Error> {
             Widget { shell } => flows::shell::main(&shell[..]),
 
             Fn { func, args } => flows::func::main(func.clone(), args.to_vec())
-                .with_context(|| format!("Failed to execute function {}", func)),
+                .with_context(|| format!("Failed to execute function `{}`", func)),
 
             Repo { cmd } => match cmd {
                 RepoCommand::Add { uri } => flows::repo::add(uri.clone())
-                    .with_context(|| format!("Failed to import cheatsheets from {}", uri)),
+                    .with_context(|| format!("Failed to import cheatsheets from `{}`", uri)),
                 RepoCommand::Browse => {
                     flows::repo::browse().context("Failed to browse featured cheatsheets")
                 }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -9,7 +9,7 @@ pub fn handle_config(mut config: Config) -> Result<(), Box<dyn Error>> {
     match config.cmd.as_mut() {
         None => flows::core::main(Variant::Core, config, true),
         Some(c) => match c {
-            Preview { line } => flows::preview::main(&line[..]),
+            Preview { line } => Ok(flows::preview::main(&line[..])?),
             Query { query } => flows::query::main(query.clone(), config),
             Best { query, args } => flows::best::main(query.clone(), args.to_vec(), config),
             Search { query } => flows::search::main(query.clone(), config),

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -3,25 +3,33 @@ use crate::flows::core::Variant;
 use crate::structures::option::Command::{Best, Fn, Preview, Query, Repo, Search, Widget};
 use crate::structures::option::{Config, RepoCommand};
 use anyhow::Context;
-use std::error::Error;
+use anyhow::Error;
 
-pub fn handle_config(mut config: Config) -> Result<(), Box<dyn Error>> {
+pub fn handle_config(mut config: Config) -> Result<(), Error> {
     match config.cmd.as_mut() {
-        None => flows::core::main(Variant::Core, config, true),
-        Some(c) => match c {
-            Preview { line } => Ok(flows::preview::main(&line[..])?),
-            Query { query } => flows::query::main(query.clone(), config),
-            Best { query, args } => flows::best::main(query.clone(), args.to_vec(), config),
-            Search { query } => flows::search::main(query.clone(), config),
-            Widget { shell } => flows::shell::main(&shell[..]),
-            Fn { func, args } => flows::func::main(func.clone(), args.to_vec()),
-            Repo { cmd } => match cmd {
-                RepoCommand::Add { uri } => Ok(flows::repo::add(uri.clone())
-                    .with_context(|| format!("Failed to import cheatsheets from {}", uri))?),
-                RepoCommand::Browse => {
-                    Ok(flows::repo::browse().context("Failed to browse featured cheatsheets")?)
-                }
-            },
-        },
+        None => Ok(flows::core::main(Variant::Core, config, true)
+            .expect("TODO: convert this flow fn to anyhow error")),
+        Some(c) => {
+            match c {
+                Preview { line } => flows::preview::main(&line[..]),
+                Query { query } => Ok(flows::query::main(query.clone(), config)
+                    .expect("TODO: convert this flow fn to anyhow error")),
+                Best { query, args } => Ok(flows::best::main(query.clone(), args.to_vec(), config)
+                    .expect("TODO: convert this flow fn to anyhow error")),
+                Search { query } => Ok(flows::search::main(query.clone(), config)
+                    .expect("TODO: convert this flow fn to anyhow error")),
+                Widget { shell } => Ok(flows::shell::main(&shell[..])
+                    .expect("TODO: convert this flow fn to anyhow error")),
+                Fn { func, args } => flows::func::main(func.clone(), args.to_vec())
+                    .with_context(|| format!("Failed to execute function {}", func)),
+                Repo { cmd } => match cmd {
+                    RepoCommand::Add { uri } => flows::repo::add(uri.clone())
+                        .with_context(|| format!("Failed to import cheatsheets from {}", uri)),
+                    RepoCommand::Browse => {
+                        flows::repo::browse().context("Failed to browse featured cheatsheets")
+                    }
+                },
+            }
+        }
     }
 }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -5,8 +5,8 @@ use crate::structures::option::{Config, RepoCommand};
 use anyhow::Context;
 use anyhow::Error;
 
-pub fn handle_config(mut config: Config) -> Result<(), Error> {
-    match config.cmd.as_mut() {
+pub fn handle_config(config: Config) -> Result<(), Error> {
+    match config.cmd.as_ref() {
         None => flows::core::main(Variant::Core, config, true),
 
         Some(c) => match c {

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -9,37 +9,34 @@ pub fn handle_config(mut config: Config) -> Result<(), Error> {
     match config.cmd.as_mut() {
         None => flows::core::main(Variant::Core, config, true),
 
-        Some(c) => {
-            match c {
-                Preview { line } => flows::preview::main(&line[..]),
+        Some(c) => match c {
+            Preview { line } => flows::preview::main(&line[..]),
 
-                Query { query } => {
-                    let error_string = format!("Failed to filter cheatsheets for {}", &query);
-                    flows::query::main(query.clone(), config).context(error_string)
-                }
-
-                Best { query, args } => {
-                    let error_string = format!("Failed to execute snippet similar to {}", &query);
-                    flows::best::main(query.clone(), args.to_vec(), config).context(error_string)
-                }
-
-                Search { query } => flows::search::main(query.clone(), config)
-                    .context("Failed to search for online cheatsheets"),
-
-                Widget { shell } => Ok(flows::shell::main(&shell[..])
-                    .expect("TODO: convert this flow fn to anyhow error")),
-
-                Fn { func, args } => flows::func::main(func.clone(), args.to_vec())
-                    .with_context(|| format!("Failed to execute function {}", func)),
-
-                Repo { cmd } => match cmd {
-                    RepoCommand::Add { uri } => flows::repo::add(uri.clone())
-                        .with_context(|| format!("Failed to import cheatsheets from {}", uri)),
-                    RepoCommand::Browse => {
-                        flows::repo::browse().context("Failed to browse featured cheatsheets")
-                    }
-                },
+            Query { query } => {
+                let error_string = format!("Failed to filter cheatsheets for {}", &query);
+                flows::query::main(query.clone(), config).context(error_string)
             }
-        }
+
+            Best { query, args } => {
+                let error_string = format!("Failed to execute snippet similar to {}", &query);
+                flows::best::main(query.clone(), args.to_vec(), config).context(error_string)
+            }
+
+            Search { query } => flows::search::main(query.clone(), config)
+                .context("Failed to search for online cheatsheets"),
+
+            Widget { shell } => flows::shell::main(&shell[..]),
+
+            Fn { func, args } => flows::func::main(func.clone(), args.to_vec())
+                .with_context(|| format!("Failed to execute function {}", func)),
+
+            Repo { cmd } => match cmd {
+                RepoCommand::Add { uri } => flows::repo::add(uri.clone())
+                    .with_context(|| format!("Failed to import cheatsheets from {}", uri)),
+                RepoCommand::Browse => {
+                    flows::repo::browse().context("Failed to browse featured cheatsheets")
+                }
+            },
+        },
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,4 +15,5 @@ mod terminal;
 mod welcome;
 
 pub use handler::handle_config;
+pub use structures::error::file_issue::FileAnIssue;
 pub use structures::option::{config_from_env, config_from_iter};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
 #[macro_use]
 extern crate lazy_static;
+#[macro_use]
+extern crate anyhow;
 
 mod display;
 mod filesystem;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -5,6 +5,7 @@ use crate::structures::fnv::HashLine;
 use crate::structures::fzf::{Opts as FzfOpts, SuggestionType};
 use crate::structures::option::Config;
 use crate::welcome;
+use anyhow::Error;
 use regex::Regex;
 use std::collections::HashSet;
 use std::fs;
@@ -160,11 +161,14 @@ fn read_file(
     false
 }
 
-pub fn read_all(config: &Config, stdin: &mut std::process::ChildStdin) -> VariableMap {
+pub fn read_all(
+    config: &Config,
+    stdin: &mut std::process::ChildStdin,
+) -> Result<VariableMap, Error> {
     let mut variables = VariableMap::new();
     let mut found_something = false;
     let mut visited_lines = HashSet::new();
-    let paths = filesystem::cheat_paths(config);
+    let paths = filesystem::cheat_paths(config)?;
     let folders = paths.split(':');
 
     for folder in folders {
@@ -186,7 +190,7 @@ pub fn read_all(config: &Config, stdin: &mut std::process::ChildStdin) -> Variab
         welcome::cheatsheet(stdin);
     }
 
-    variables
+    Ok(variables)
 }
 
 #[cfg(test)]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -5,7 +5,7 @@ use crate::structures::fnv::HashLine;
 use crate::structures::fzf::{Opts as FzfOpts, SuggestionType};
 use crate::structures::option::Config;
 use crate::welcome;
-use anyhow::Error;
+use anyhow::{Context, Error};
 use regex::Regex;
 use std::collections::HashSet;
 use std::fs;
@@ -16,31 +16,64 @@ lazy_static! {
         Regex::new(r"^\$\s*([^:]+):(.*)").expect("Invalid regex");
 }
 
-fn parse_opts(text: &str) -> FzfOpts {
+fn parse_opts(text: &str) -> Result<FzfOpts, Error> {
     let mut multi = false;
     let mut prevent_extra = false;
     let mut opts = FzfOpts::default();
-    let parts_vec = shellwords::split(text).unwrap();
-    let mut parts = parts_vec.into_iter();
+    let parts = shellwords::split(text)
+        .map_err(|_| anyhow!("Given options are missing a closing quote"))?;
 
-    while let Some(p) = parts.next() {
-        match p.as_str() {
-            "--multi" => multi = true,
-            "--prevent-extra" => prevent_extra = true,
-            "--headers" | "--header-lines" => {
-                opts.header_lines = parts.next().unwrap().parse::<u8>().unwrap()
+    parts
+        .into_iter()
+        .filter(|part| {
+            // We'll take parts in pairs of 2: (argument, value). Flags don't have a value tho, so we filter and handle them beforehand.
+            match part.as_str() {
+                "--multi" => {
+                    multi = true;
+                    false
+                }
+                "--prevent-extra" => {
+                    prevent_extra = true;
+                    false
+                }
+                _ => true,
             }
-            "--column" => opts.column = Some(parts.next().unwrap().parse::<u8>().unwrap()),
-            "--delimiter" => opts.delimiter = Some(parts.next().unwrap().to_string()),
-            "--query" => opts.query = Some(parts.next().unwrap().to_string()),
-            "--filter" => opts.filter = Some(parts.next().unwrap().to_string()),
-            "--preview" => opts.preview = Some(parts.next().unwrap().to_string()),
-            "--preview-window" => opts.preview_window = Some(parts.next().unwrap().to_string()),
-            "--header" => opts.header = Some(parts.next().unwrap().to_string()),
-            "--overrides" => opts.overrides = Some(parts.next().unwrap().to_string()),
-            _ => (),
-        }
-    }
+        })
+        .collect::<Vec<_>>()
+        .chunks(2)
+        .map(|flag_and_value| {
+            if let [flag, value] = flag_and_value {
+                match flag.as_str() {
+                    "--headers" | "--header-lines" => {
+                        opts.header_lines = value
+                            .parse::<u8>()
+                            .context("Value for `--headers` is invalid u8")?
+                    }
+                    "--column" => {
+                        opts.column = Some(
+                            value
+                                .parse::<u8>()
+                                .context("Value for `--column` is invalid u8")?,
+                        )
+                    }
+                    "--delimiter" => opts.delimiter = Some(value.to_string()),
+                    "--query" => opts.query = Some(value.to_string()),
+                    "--filter" => opts.filter = Some(value.to_string()),
+                    "--preview" => opts.preview = Some(value.to_string()),
+                    "--preview-window" => opts.preview_window = Some(value.to_string()),
+                    "--header" => opts.header = Some(value.to_string()),
+                    "--overrides" => opts.overrides = Some(value.to_string()),
+                    _ => (),
+                }
+                Ok(())
+            } else if let [flag] = flag_and_value {
+                Err(anyhow!("No value provided for the flag {}", flag))
+            } else {
+                unreachable!() // Chunking by 2 allows only for tuples of 1 or 2 items...
+            }
+        })
+        .collect::<Result<_, _>>()
+        .context("Failed to parse fzf options")?;
 
     let suggestion_type = match (multi, prevent_extra) {
         (true, _) => SuggestionType::MultipleSelections, // multi wins over allow-extra
@@ -49,16 +82,31 @@ fn parse_opts(text: &str) -> FzfOpts {
     };
     opts.suggestion_type = suggestion_type;
 
-    opts
+    Ok(opts)
 }
 
-fn parse_variable_line(line: &str) -> (&str, &str, Option<FzfOpts>) {
-    let caps = VAR_LINE_REGEX.captures(line).unwrap();
-    let variable = caps.get(1).unwrap().as_str().trim();
-    let mut command_plus_opts = caps.get(2).unwrap().as_str().split("---");
-    let command = command_plus_opts.next().unwrap();
-    let command_options = command_plus_opts.next().map(parse_opts);
-    (variable, command, command_options)
+fn parse_variable_line(line: &str) -> Result<(&str, &str, Option<FzfOpts>), Error> {
+    let caps = VAR_LINE_REGEX.captures(line).ok_or_else(|| {
+        anyhow!(
+            "No variables, command, and options found in the line {}",
+            line
+        )
+    })?;
+    let variable = caps
+        .get(1)
+        .ok_or_else(|| anyhow!("No variable captured in the line {}", line))?
+        .as_str()
+        .trim();
+    let mut command_plus_opts = caps
+        .get(2)
+        .ok_or_else(|| anyhow!("No command and options captured in the line {}", line))?
+        .as_str()
+        .split("---");
+    let command = command_plus_opts
+        .next()
+        .ok_or_else(|| anyhow!("No command captured in the line {}", line))?;
+    let command_options = command_plus_opts.next().map(parse_opts).transpose()?;
+    Ok((variable, command, command_options))
 }
 
 fn write_cmd(
@@ -68,16 +116,16 @@ fn write_cmd(
     tag_width: usize,
     comment_width: usize,
     stdin: &mut std::process::ChildStdin,
-) -> bool {
+) -> Result<(), Error> {
     if snippet.is_empty() {
-        true
+        Ok(())
     } else {
         stdin
             .write_all(
                 display::format_line(&tags, &comment, &snippet, tag_width, comment_width)
                     .as_bytes(),
             )
-            .is_ok()
+            .context("Failed to write command to fzf's stdin")
     }
 }
 
@@ -86,7 +134,7 @@ fn read_file(
     variables: &mut VariableMap,
     visited_lines: &mut HashSet<u64>,
     stdin: &mut std::process::ChildStdin,
-) -> bool {
+) -> Result<(), Error> {
     let mut tags = String::from("");
     let mut comment = String::from("");
     let mut snippet = String::from("");
@@ -94,71 +142,71 @@ fn read_file(
 
     let (tag_width, comment_width) = *display::WIDTHS;
 
-    if let Ok(lines) = filesystem::read_lines(path) {
-        for l in lines {
-            if should_break {
-                break;
-            }
-
-            let line = l.unwrap();
-
-            // duplicate
-            if !tags.is_empty() && !comment.is_empty() {}
-
-            // blank
-            if line.is_empty() {
-            }
-            // tag
-            else if line.starts_with('%') {
-                if !write_cmd(&tags, &comment, &snippet, tag_width, comment_width, stdin) {
-                    should_break = true
-                }
-                snippet = String::from("");
-                tags = String::from(&line[2..]);
-            }
-            // metacomment
-            else if line.starts_with(';') {
-            }
-            // comment
-            else if line.starts_with('#') {
-                if !write_cmd(&tags, &comment, &snippet, tag_width, comment_width, stdin) {
-                    should_break = true
-                }
-                snippet = String::from("");
-                comment = String::from(&line[2..]);
-            }
-            // variable
-            else if line.starts_with('$') {
-                if !write_cmd(&tags, &comment, &snippet, tag_width, comment_width, stdin) {
-                    should_break = true
-                }
-                snippet = String::from("");
-                let (variable, command, opts) = parse_variable_line(&line);
-                variables.insert(&tags, &variable, (String::from(command), opts));
-            }
-            // snippet
-            else {
-                let hash = format!("{}{}", &comment, &line).hash_line();
-                if visited_lines.contains(&hash) {
-                    continue;
-                }
-                visited_lines.insert(hash);
-
-                if !(&snippet).is_empty() {
-                    snippet.push_str(display::LINE_SEPARATOR);
-                }
-                snippet.push_str(&line);
-            }
+    for (line_nr, line) in filesystem::read_lines(path)?.into_iter().enumerate() {
+        if should_break {
+            break;
         }
 
-        if !should_break {
-            write_cmd(&tags, &comment, &snippet, tag_width, comment_width, stdin);
-        }
+        // duplicate
+        if !tags.is_empty() && !comment.is_empty() {}
 
-        return true;
+        // blank
+        if line.is_empty() {
+        }
+        // tag
+        else if line.starts_with('%') {
+            if write_cmd(&tags, &comment, &snippet, tag_width, comment_width, stdin).is_err() {
+                should_break = true
+            }
+            snippet = String::from("");
+            tags = String::from(&line[2..]);
+        }
+        // metacomment
+        else if line.starts_with(';') {
+        }
+        // comment
+        else if line.starts_with('#') {
+            if write_cmd(&tags, &comment, &snippet, tag_width, comment_width, stdin).is_err() {
+                should_break = true
+            }
+            snippet = String::from("");
+            comment = String::from(&line[2..]);
+        }
+        // variable
+        else if line.starts_with('$') {
+            if write_cmd(&tags, &comment, &snippet, tag_width, comment_width, stdin).is_err() {
+                should_break = true
+            }
+            snippet = String::from("");
+            let (variable, command, opts) = parse_variable_line(&line).with_context(|| {
+                format!(
+                    "Failed to parse variable line. See line nr.{} in cheatsheet {}",
+                    line_nr + 1,
+                    path
+                )
+            })?;
+            variables.insert(&tags, &variable, (String::from(command), opts));
+        }
+        // snippet
+        else {
+            let hash = format!("{}{}", &comment, &line).hash_line();
+            if visited_lines.contains(&hash) {
+                continue;
+            }
+            visited_lines.insert(hash);
+
+            if !(&snippet).is_empty() {
+                snippet.push_str(display::LINE_SEPARATOR);
+            }
+            snippet.push_str(&line);
+        }
     }
 
-    false
+    if !should_break {
+        let _ = write_cmd(&tags, &comment, &snippet, tag_width, comment_width, stdin);
+    }
+
+    Ok(())
 }
 
 pub fn read_all(
@@ -172,16 +220,21 @@ pub fn read_all(
     let folders = paths.split(':');
 
     for folder in folders {
-        if let Ok(paths) = fs::read_dir(folder) {
-            for path in paths {
-                let path = path.unwrap().path();
-                let path_str = path.to_str().unwrap();
-                if path_str.ends_with(".cheat")
-                    && read_file(path_str, &mut variables, &mut visited_lines, stdin)
-                    && !found_something
-                {
-                    found_something = true;
-                }
+        let dir_entries =
+            fs::read_dir(folder).with_context(|| format!("Unable to read directory {}", folder))?;
+
+        for entry in dir_entries {
+            let path = entry
+                .with_context(|| format!("Unable to read directory {}", folder))?
+                .path();
+            let path_str = path
+                .to_str()
+                .ok_or_else(|| anyhow!("Invalid path {}", path.display()))?;
+            if path_str.ends_with(".cheat")
+                && read_file(path_str, &mut variables, &mut visited_lines, stdin).is_ok()
+                && !found_something
+            {
+                found_something = true;
             }
         }
     }
@@ -200,7 +253,7 @@ mod tests {
     #[test]
     fn test_parse_variable_line() {
         let (variable, command, command_options) =
-            parse_variable_line("$ user : echo -e \"$(whoami)\\nroot\" --- --allow-extra");
+            parse_variable_line("$ user : echo -e \"$(whoami)\\nroot\" --- --allow-extra").unwrap();
         assert_eq!(command, " echo -e \"$(whoami)\\nroot\" ");
         assert_eq!(variable, "user");
         assert_eq!(
@@ -223,7 +276,7 @@ mod tests {
         let mut child = Command::new("cat").stdin(Stdio::piped()).spawn().unwrap();
         let child_stdin = child.stdin.as_mut().unwrap();
         let mut visited_lines: HashSet<u64> = HashSet::new();
-        read_file(path, &mut variables, &mut visited_lines, child_stdin);
+        read_file(path, &mut variables, &mut visited_lines, child_stdin).unwrap();
         let expected_suggestion = (
             r#" echo -e "$(whoami)\nroot" "#.to_string(),
             Some(FzfOpts {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -227,18 +227,18 @@ pub fn read_all(
     let folders = paths_from_path_param(&paths);
 
     for folder in folders {
-        let dir_entries = fs::read_dir(folder).map_err(|e| UnreadableDir::new(folder, e))?;
-
-        for entry in dir_entries {
-            let path = entry.map_err(|e| UnreadableDir::new(folder, e))?.path();
-            let path_str = path
-                .to_str()
-                .ok_or_else(|| InvalidPath(path.to_path_buf()))?;
-            if path_str.ends_with(".cheat")
-                && read_file(path_str, &mut variables, &mut visited_lines, stdin).is_ok()
-                && !found_something
-            {
-                found_something = true;
+        if let Ok(dir_entries) = fs::read_dir(folder) {
+            for entry in dir_entries {
+                let path = entry.map_err(|e| UnreadableDir::new(folder, e))?.path();
+                let path_str = path
+                    .to_str()
+                    .ok_or_else(|| InvalidPath(path.to_path_buf()))?;
+                if path_str.ends_with(".cheat")
+                    && read_file(path_str, &mut variables, &mut visited_lines, stdin).is_ok()
+                    && !found_something
+                {
+                    found_something = true;
+                }
             }
         }
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -67,7 +67,7 @@ fn parse_opts(text: &str) -> Result<FzfOpts, Error> {
                 }
                 Ok(())
             } else if let [flag] = flag_and_value {
-                Err(anyhow!("No value provided for the flag {}", flag))
+                Err(anyhow!("No value provided for the flag `{}`", flag))
             } else {
                 unreachable!() // Chunking by 2 allows only for tuples of 1 or 2 items...
             }
@@ -88,23 +88,23 @@ fn parse_opts(text: &str) -> Result<FzfOpts, Error> {
 fn parse_variable_line(line: &str) -> Result<(&str, &str, Option<FzfOpts>), Error> {
     let caps = VAR_LINE_REGEX.captures(line).ok_or_else(|| {
         anyhow!(
-            "No variables, command, and options found in the line {}",
+            "No variables, command, and options found in the line `{}`",
             line
         )
     })?;
     let variable = caps
         .get(1)
-        .ok_or_else(|| anyhow!("No variable captured in the line {}", line))?
+        .ok_or_else(|| anyhow!("No variable captured in the line `{}`", line))?
         .as_str()
         .trim();
     let mut command_plus_opts = caps
         .get(2)
-        .ok_or_else(|| anyhow!("No command and options captured in the line {}", line))?
+        .ok_or_else(|| anyhow!("No command and options captured in the line `{}`", line))?
         .as_str()
         .split("---");
     let command = command_plus_opts
         .next()
-        .ok_or_else(|| anyhow!("No command captured in the line {}", line))?;
+        .ok_or_else(|| anyhow!("No command captured in the line `{}`", line))?;
     let command_options = command_plus_opts.next().map(parse_opts).transpose()?;
     Ok((variable, command, command_options))
 }
@@ -180,7 +180,7 @@ fn read_file(
             snippet = String::from("");
             let (variable, command, opts) = parse_variable_line(&line).with_context(|| {
                 format!(
-                    "Failed to parse variable line. See line nr.{} in cheatsheet {}",
+                    "Failed to parse variable line. See line nr.{} in cheatsheet `{}`",
                     line_nr + 1,
                     path
                 )
@@ -224,16 +224,16 @@ pub fn read_all(
     let folders = paths_from_path_param(&paths);
 
     for folder in folders {
-        let dir_entries =
-            fs::read_dir(folder).with_context(|| format!("Unable to read directory {}", folder))?;
+        let dir_entries = fs::read_dir(folder)
+            .with_context(|| format!("Unable to read directory `{}`", folder))?;
 
         for entry in dir_entries {
             let path = entry
-                .with_context(|| format!("Unable to read directory {}", folder))?
+                .with_context(|| format!("Unable to read directory `{}`", folder))?
                 .path();
             let path_str = path
                 .to_str()
-                .ok_or_else(|| anyhow!("Invalid path {}", path.display()))?;
+                .ok_or_else(|| anyhow!("Invalid path `{}`", path.display()))?;
             if path_str.ends_with(".cheat")
                 && read_file(path_str, &mut variables, &mut visited_lines, stdin).is_ok()
                 && !found_something

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3,7 +3,7 @@ use crate::filesystem;
 use crate::structures::cheat::VariableMap;
 use crate::structures::fnv::HashLine;
 use crate::structures::fzf::{Opts as FzfOpts, SuggestionType};
-use crate::structures::option::Config;
+use crate::structures::{error::FilesystemError, option::Config};
 use crate::welcome;
 use anyhow::{Context, Error};
 use regex::Regex;
@@ -233,7 +233,7 @@ pub fn read_all(
                 .path();
             let path_str = path
                 .to_str()
-                .ok_or_else(|| anyhow!("Invalid path `{}`", path.display()))?;
+                .ok_or_else(|| FilesystemError::InvalidPath(path.to_path_buf()))?;
             if path_str.ends_with(".cheat")
                 && read_file(path_str, &mut variables, &mut visited_lines, stdin).is_ok()
                 && !found_something

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3,7 +3,7 @@ use crate::filesystem;
 use crate::structures::cheat::VariableMap;
 use crate::structures::fnv::HashLine;
 use crate::structures::fzf::{Opts as FzfOpts, SuggestionType};
-use crate::structures::{error::FilesystemError, option::Config};
+use crate::structures::{error::filesystem::InvalidPath, option::Config};
 use crate::welcome;
 use anyhow::{Context, Error};
 use regex::Regex;
@@ -233,7 +233,7 @@ pub fn read_all(
                 .path();
             let path_str = path
                 .to_str()
-                .ok_or_else(|| FilesystemError::InvalidPath(path.to_path_buf()))?;
+                .ok_or_else(|| InvalidPath(path.to_path_buf()))?;
             if path_str.ends_with(".cheat")
                 && read_file(path_str, &mut variables, &mut visited_lines, stdin).is_ok()
                 && !found_something

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -145,7 +145,10 @@ fn read_file(
 
     let (tag_width, comment_width) = *display::WIDTHS;
 
-    for (line_nr, line) in filesystem::read_lines(path)?.into_iter().enumerate() {
+    for (line_nr, line_result) in filesystem::read_lines(path)?.enumerate() {
+        let line = line_result
+            .with_context(|| format!("Failed to read line nr.{} from `{}`", line_nr, path))?;
+
         if should_break {
             break;
         }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -10,6 +10,11 @@ use std::collections::HashSet;
 use std::fs;
 use std::io::Write;
 
+lazy_static! {
+    pub static ref VAR_LINE_REGEX: Regex =
+        Regex::new(r"^\$\s*([^:]+):(.*)").expect("Invalid regex");
+}
+
 fn parse_opts(text: &str) -> FzfOpts {
     let mut multi = false;
     let mut prevent_extra = false;
@@ -47,8 +52,7 @@ fn parse_opts(text: &str) -> FzfOpts {
 }
 
 fn parse_variable_line(line: &str) -> (&str, &str, Option<FzfOpts>) {
-    let re = Regex::new(r"^\$\s*([^:]+):(.*)").unwrap();
-    let caps = re.captures(line).unwrap();
+    let caps = VAR_LINE_REGEX.captures(line).unwrap();
     let variable = caps.get(1).unwrap().as_str().trim();
     let mut command_plus_opts = caps.get(2).unwrap().as_str().split("---");
     let command = command_plus_opts.next().unwrap();

--- a/src/structures/error.rs
+++ b/src/structures/error.rs
@@ -1,7 +1,0 @@
-use std::{fmt::Debug, path::PathBuf};
-use thiserror::Error;
-#[derive(Error, Debug)]
-pub enum FilesystemError {
-    #[error("Invalid path `{0}`")]
-    InvalidPath(PathBuf),
-}

--- a/src/structures/error.rs
+++ b/src/structures/error.rs
@@ -1,0 +1,7 @@
+use std::{fmt::Debug, path::PathBuf};
+use thiserror::Error;
+#[derive(Error, Debug)]
+pub enum FilesystemError {
+    #[error("Invalid path `{0}`")]
+    InvalidPath(PathBuf),
+}

--- a/src/structures/error/command.rs
+++ b/src/structures/error/command.rs
@@ -1,0 +1,22 @@
+use std::fmt::Debug;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+#[error("Failed to spawn child process `bash` to execute `{command}`")]
+pub struct BashSpawnError {
+    command: String,
+    #[source]
+    source: anyhow::Error,
+}
+
+impl BashSpawnError {
+    pub fn new<SourceError>(command: impl Into<String>, source: SourceError) -> Self
+    where
+        SourceError: std::error::Error + Sync + Send + 'static,
+    {
+        BashSpawnError {
+            command: command.into(),
+            source: source.into(),
+        }
+    }
+}

--- a/src/structures/error/file_issue.rs
+++ b/src/structures/error/file_issue.rs
@@ -1,0 +1,19 @@
+use std::fmt::Debug;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+#[error(
+    "Hey listen! Navi encountered a problem.
+
+Do you think this is a bug? File an issue at https://github.com/denisidoro/navi."
+)]
+pub struct FileAnIssue(#[source] anyhow::Error);
+
+impl FileAnIssue {
+    pub fn new<SourceError>(source: SourceError) -> Self
+    where
+        SourceError: Into<anyhow::Error>,
+    {
+        FileAnIssue(source.into())
+    }
+}

--- a/src/structures/error/file_issue.rs
+++ b/src/structures/error/file_issue.rs
@@ -3,17 +3,21 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 #[error(
-    "Hey listen! Navi encountered a problem.
-
+    "\rHey listen! Navi encountered a problem.
 Do you think this is a bug? File an issue at https://github.com/denisidoro/navi."
 )]
-pub struct FileAnIssue(#[source] anyhow::Error);
+pub struct FileAnIssue {
+    #[source]
+    source: anyhow::Error,
+}
 
 impl FileAnIssue {
     pub fn new<SourceError>(source: SourceError) -> Self
     where
         SourceError: Into<anyhow::Error>,
     {
-        FileAnIssue(source.into())
+        FileAnIssue {
+            source: source.into(),
+        }
     }
 }

--- a/src/structures/error/filesystem.rs
+++ b/src/structures/error/filesystem.rs
@@ -1,5 +1,27 @@
 use std::{fmt::Debug, path::PathBuf};
 use thiserror::Error;
+
 #[derive(Error, Debug)]
 #[error("Invalid path `{0}`")]
 pub struct InvalidPath(pub PathBuf);
+
+#[derive(Error, Debug)]
+#[error("Unable to read directory `{dir}`")]
+pub struct UnreadableDir {
+    dir: PathBuf,
+    #[source]
+    source: anyhow::Error,
+}
+
+impl UnreadableDir {
+    pub fn new<DirT, SourceError>(dir: DirT, source: SourceError) -> Self
+    where
+        DirT: Into<PathBuf>,
+        SourceError: std::error::Error + Sync + Send + 'static,
+    {
+        UnreadableDir {
+            dir: dir.into(),
+            source: source.into(),
+        }
+    }
+}

--- a/src/structures/error/filesystem.rs
+++ b/src/structures/error/filesystem.rs
@@ -1,0 +1,5 @@
+use std::{fmt::Debug, path::PathBuf};
+use thiserror::Error;
+#[derive(Error, Debug)]
+#[error("Invalid path `{0}`")]
+pub struct InvalidPath(pub PathBuf);

--- a/src/structures/error/mod.rs
+++ b/src/structures/error/mod.rs
@@ -1,0 +1,1 @@
+pub mod filesystem;

--- a/src/structures/error/mod.rs
+++ b/src/structures/error/mod.rs
@@ -1,2 +1,3 @@
 pub mod command;
+pub mod file_issue;
 pub mod filesystem;

--- a/src/structures/error/mod.rs
+++ b/src/structures/error/mod.rs
@@ -1,1 +1,2 @@
+pub mod command;
 pub mod filesystem;

--- a/src/structures/mod.rs
+++ b/src/structures/mod.rs
@@ -1,4 +1,5 @@
 pub mod cheat;
+pub mod error;
 pub mod fnv;
 pub mod fzf;
 pub mod option;

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -11,7 +11,7 @@ fn width_with_shell_out() -> u16 {
             .arg("size")
             .stderr(Stdio::inherit())
             .output()
-            .unwrap()
+            .expect("Failed to execute stty")
     } else {
         Command::new("stty")
             .arg("size")
@@ -19,15 +19,16 @@ fn width_with_shell_out() -> u16 {
             .arg("/dev/stderr")
             .stderr(Stdio::inherit())
             .output()
-            .unwrap()
+            .expect("Failed to execute stty")
     };
 
     match output.status.code() {
         Some(0) => {
-            let stdout = String::from_utf8(output.stdout).unwrap();
+            let stdout = String::from_utf8(output.stdout).expect("Invalid utf8 output from stty");
             let mut data = stdout.split_whitespace();
             data.next();
-            u16::from_str_radix(data.next().unwrap(), 10).unwrap()
+            u16::from_str_radix(data.next().expect("Not enough data"), 10)
+                .expect("Invalid base-10 number")
         }
         _ => 40,
     }

--- a/src/welcome.rs
+++ b/src/welcome.rs
@@ -4,7 +4,7 @@ use std::io::Write;
 fn add_msg(tag: &str, comment: &str, snippet: &str, stdin: &mut std::process::ChildStdin) {
     stdin
         .write_all(display::format_line(tag, comment, snippet, 20, 60).as_bytes())
-        .unwrap();
+        .expect("Could not write to fzf's stdin");
 }
 
 pub fn cheatsheet(stdin: &mut std::process::ChildStdin) {


### PR DESCRIPTION
PR for #291

- Currently adding error messages based on context. However, I'm not familiar with the code base so **thorough review is highly recommended** to improve error messages
- ... especially for the `fzf` and `core` modules.

TODO:
- [x] Every call to `bash` now has an error message similar to "Failed to execute bash". This should probably be related to the actual command ran, i.e. params given to `bash`.
- [x] A lot of `anyhow::[with_]context()` is used to add, well, context. It might be better to create custom error variants for repetitive errors.
- [x] `navi fn welcome` is broken.
- [x] Add "file a bug report" message to top-level error.
- [x] Test for potential breakages. Logic changes have been avoided as much as possible but stuff happens.
- [x] `navi repo browse` and `navi repo add https://github.com/denisidoro/navi` crash. Root cause is `fzf` not returning data due to window layout error.
![image](https://user-images.githubusercontent.com/25766329/77264618-005c4880-6c9b-11ea-87fe-0a22e190d9c3.png)
- [x] bump version

