### PR TITLE
Fix panic when trimming text with non-ASCII characters

### DIFF
--- a/src/display.rs
+++ b/src/display.rs
@@ -51,7 +51,7 @@ pub fn preview(comment: &str, tags: &str, snippet: &str) {
 
 fn limit_str(text: &str, length: usize) -> String {
     if text.len() > length {
-        format!("{}…", &text[..length - 1])
+        format!("{}…", text.chars().take(length).collect::<String>())
     } else {
         format!("{:width$}", text, width = length)
     }


### PR DESCRIPTION
Fixes #310 