### PR TITLE
Add support for skim binary instead of fzf binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,6 @@ license = "Apache-2.0"
 [badges]
 travis-ci = { repository = "denisidoro/navi", branch = "master" }
 
-[features]
-default = []
-use_skim = []
-
 [dependencies]
 regex = "1.3.4"
 structopt = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,10 @@ license = "Apache-2.0"
 [badges]
 travis-ci = { repository = "denisidoro/navi", branch = "master" }
 
+[features]
+default = []
+use_skim = []
+
 [dependencies]
 regex = "1.3.4"
 structopt = "0.3"

--- a/src/finder/fzf.rs
+++ b/src/finder/fzf.rs
@@ -1,0 +1,127 @@
+use super::{get_column, parse_output_single};
+use crate::display;
+use crate::structures::cheat::VariableMap;
+use crate::structures::finder::{Opts, SuggestionType};
+use anyhow::Context;
+use anyhow::Error;
+use std::process;
+use std::process::{Command, Stdio};
+
+pub fn call<F>(opts: Opts, stdin_fn: F) -> Result<(String, Option<VariableMap>), Error>
+where
+    F: Fn(&mut process::ChildStdin) -> Result<Option<VariableMap>, Error>,
+{
+    let mut fzf_command = Command::new("fzf");
+
+    fzf_command.args(&[
+        "--preview-window",
+        "up:2",
+        "--with-nth",
+        "1,2,3",
+        "--delimiter",
+        display::DELIMITER.to_string().as_str(),
+        "--ansi",
+        "--bind",
+        "ctrl-j:down,ctrl-k:up",
+        "--exact",
+    ]);
+
+    if opts.autoselect {
+        fzf_command.arg("--select-1");
+    }
+
+    match opts.suggestion_type {
+        SuggestionType::MultipleSelections => {
+            fzf_command.arg("--multi");
+        }
+        SuggestionType::Disabled => {
+            fzf_command.args(&["--print-query", "--no-select-1", "--height", "1"]);
+        }
+        SuggestionType::SnippetSelection => {
+            fzf_command.args(&["--expect", "ctrl-y,enter"]);
+        }
+        SuggestionType::SingleRecommendation => {
+            fzf_command.args(&["--print-query", "--expect", "tab,enter"]);
+        }
+        _ => {}
+    }
+
+    if let Some(p) = opts.preview {
+        fzf_command.args(&["--preview", &p]);
+    }
+
+    if let Some(q) = opts.query {
+        fzf_command.args(&["--query", &q]);
+    }
+
+    if let Some(f) = opts.filter {
+        fzf_command.args(&["--filter", &f]);
+    }
+
+    if let Some(h) = opts.header {
+        fzf_command.args(&["--header", &h]);
+    }
+
+    if let Some(p) = opts.prompt {
+        fzf_command.args(&["--prompt", &p]);
+    }
+
+    if let Some(pw) = opts.preview_window {
+        fzf_command.args(&["--preview-window", &pw]);
+    }
+
+    if opts.header_lines > 0 {
+        fzf_command.args(&["--header-lines", format!("{}", opts.header_lines).as_str()]);
+    }
+
+    if let Some(o) = opts.overrides {
+        o.as_str()
+            .split(' ')
+            .map(|s| s.to_string())
+            .filter(|s| !s.is_empty())
+            .for_each(|s| {
+                fzf_command.arg(s);
+            });
+    }
+
+    let child = fzf_command
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn();
+
+    let mut child = match child {
+        Ok(x) => x,
+        Err(_) => {
+            eprintln!("navi was unable to call fzf.\nPlease make sure it's correctly installed\nRefer to https://github.com/junegunn/fzf for more info.");
+            process::exit(33)
+        }
+    };
+
+    let stdin = child
+        .stdin
+        .as_mut()
+        .ok_or_else(|| anyhow!("Unable to acquire stdin of fzf"))?;
+    let result_map = stdin_fn(stdin).context("Failed to pass data to fzf")?;
+
+    let out = child.wait_with_output().context("Failed to wait for fzf")?;
+
+    let text = match out.status.code() {
+        Some(0) | Some(1) | Some(2) => {
+            String::from_utf8(out.stdout).context("Invalid utf8 received from fzf")?
+        }
+        Some(130) => process::exit(130),
+        _ => {
+            let err = String::from_utf8(out.stderr)
+                .unwrap_or_else(|_| "<stderr contains invalid UTF-8>".to_owned());
+            panic!("External command failed:\n {}", err)
+        }
+    };
+
+    let out = get_column(
+        parse_output_single(text, opts.suggestion_type)?,
+        opts.column,
+        opts.delimiter.as_deref(),
+    );
+
+    Ok((out, result_map))
+}

--- a/src/finder/fzf.rs
+++ b/src/finder/fzf.rs
@@ -1,4 +1,4 @@
-use super::{get_column, parse_output_single};
+use super::{get_column, parse_output_single, Finder};
 use crate::display;
 use crate::structures::cheat::VariableMap;
 use crate::structures::finder::{Opts, SuggestionType};
@@ -7,121 +7,126 @@ use anyhow::Error;
 use std::process;
 use std::process::{Command, Stdio};
 
-pub fn call<F>(opts: Opts, stdin_fn: F) -> Result<(String, Option<VariableMap>), Error>
-where
-    F: Fn(&mut process::ChildStdin) -> Result<Option<VariableMap>, Error>,
-{
-    let mut fzf_command = Command::new("fzf");
+#[derive(Debug)]
+pub struct FzfFinder;
 
-    fzf_command.args(&[
-        "--preview-window",
-        "up:2",
-        "--with-nth",
-        "1,2,3",
-        "--delimiter",
-        display::DELIMITER.to_string().as_str(),
-        "--ansi",
-        "--bind",
-        "ctrl-j:down,ctrl-k:up",
-        "--exact",
-    ]);
+impl Finder for FzfFinder {
+    fn call<F>(&self, opts: Opts, stdin_fn: F) -> Result<(String, Option<VariableMap>), Error>
+    where
+        F: Fn(&mut process::ChildStdin) -> Result<Option<VariableMap>, Error>,
+    {
+        let mut fzf_command = Command::new("fzf");
 
-    if opts.autoselect {
-        fzf_command.arg("--select-1");
-    }
+        fzf_command.args(&[
+            "--preview-window",
+            "up:2",
+            "--with-nth",
+            "1,2,3",
+            "--delimiter",
+            display::DELIMITER.to_string().as_str(),
+            "--ansi",
+            "--bind",
+            "ctrl-j:down,ctrl-k:up",
+            "--exact",
+        ]);
 
-    match opts.suggestion_type {
-        SuggestionType::MultipleSelections => {
-            fzf_command.arg("--multi");
+        if opts.autoselect {
+            fzf_command.arg("--select-1");
         }
-        SuggestionType::Disabled => {
-            fzf_command.args(&["--print-query", "--no-select-1", "--height", "1"]);
+
+        match opts.suggestion_type {
+            SuggestionType::MultipleSelections => {
+                fzf_command.arg("--multi");
+            }
+            SuggestionType::Disabled => {
+                fzf_command.args(&["--print-query", "--no-select-1", "--height", "1"]);
+            }
+            SuggestionType::SnippetSelection => {
+                fzf_command.args(&["--expect", "ctrl-y,enter"]);
+            }
+            SuggestionType::SingleRecommendation => {
+                fzf_command.args(&["--print-query", "--expect", "tab,enter"]);
+            }
+            _ => {}
         }
-        SuggestionType::SnippetSelection => {
-            fzf_command.args(&["--expect", "ctrl-y,enter"]);
+
+        if let Some(p) = opts.preview {
+            fzf_command.args(&["--preview", &p]);
         }
-        SuggestionType::SingleRecommendation => {
-            fzf_command.args(&["--print-query", "--expect", "tab,enter"]);
+
+        if let Some(q) = opts.query {
+            fzf_command.args(&["--query", &q]);
         }
-        _ => {}
-    }
 
-    if let Some(p) = opts.preview {
-        fzf_command.args(&["--preview", &p]);
-    }
-
-    if let Some(q) = opts.query {
-        fzf_command.args(&["--query", &q]);
-    }
-
-    if let Some(f) = opts.filter {
-        fzf_command.args(&["--filter", &f]);
-    }
-
-    if let Some(h) = opts.header {
-        fzf_command.args(&["--header", &h]);
-    }
-
-    if let Some(p) = opts.prompt {
-        fzf_command.args(&["--prompt", &p]);
-    }
-
-    if let Some(pw) = opts.preview_window {
-        fzf_command.args(&["--preview-window", &pw]);
-    }
-
-    if opts.header_lines > 0 {
-        fzf_command.args(&["--header-lines", format!("{}", opts.header_lines).as_str()]);
-    }
-
-    if let Some(o) = opts.overrides {
-        o.as_str()
-            .split(' ')
-            .map(|s| s.to_string())
-            .filter(|s| !s.is_empty())
-            .for_each(|s| {
-                fzf_command.arg(s);
-            });
-    }
-
-    let child = fzf_command
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .spawn();
-
-    let mut child = match child {
-        Ok(x) => x,
-        Err(_) => {
-            eprintln!("navi was unable to call fzf.\nPlease make sure it's correctly installed\nRefer to https://github.com/junegunn/fzf for more info.");
-            process::exit(33)
+        if let Some(f) = opts.filter {
+            fzf_command.args(&["--filter", &f]);
         }
-    };
 
-    let stdin = child
-        .stdin
-        .as_mut()
-        .ok_or_else(|| anyhow!("Unable to acquire stdin of fzf"))?;
-    let result_map = stdin_fn(stdin).context("Failed to pass data to fzf")?;
-
-    let out = child.wait_with_output().context("Failed to wait for fzf")?;
-
-    let text = match out.status.code() {
-        Some(0) | Some(1) | Some(2) => {
-            String::from_utf8(out.stdout).context("Invalid utf8 received from fzf")?
+        if let Some(h) = opts.header {
+            fzf_command.args(&["--header", &h]);
         }
-        Some(130) => process::exit(130),
-        _ => {
-            let err = String::from_utf8(out.stderr)
-                .unwrap_or_else(|_| "<stderr contains invalid UTF-8>".to_owned());
-            panic!("External command failed:\n {}", err)
+
+        if let Some(p) = opts.prompt {
+            fzf_command.args(&["--prompt", &p]);
         }
-    };
 
-    let out = get_column(
-        parse_output_single(text, opts.suggestion_type)?,
-        opts.column,
-        opts.delimiter.as_deref(),
-    );
+        if let Some(pw) = opts.preview_window {
+            fzf_command.args(&["--preview-window", &pw]);
+        }
 
-    Ok((out, result_map))
+        if opts.header_lines > 0 {
+            fzf_command.args(&["--header-lines", format!("{}", opts.header_lines).as_str()]);
+        }
+
+        if let Some(o) = opts.overrides {
+            o.as_str()
+                .split(' ')
+                .map(|s| s.to_string())
+                .filter(|s| !s.is_empty())
+                .for_each(|s| {
+                    fzf_command.arg(s);
+                });
+        }
+
+        let child = fzf_command
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn();
+
+        let mut child = match child {
+            Ok(x) => x,
+            Err(_) => {
+                eprintln!("navi was unable to call fzf.\nPlease make sure it's correctly installed\nRefer to https://github.com/junegunn/fzf for more info.");
+                process::exit(33)
+            }
+        };
+
+        let stdin = child
+            .stdin
+            .as_mut()
+            .ok_or_else(|| anyhow!("Unable to acquire stdin of fzf"))?;
+        let result_map = stdin_fn(stdin).context("Failed to pass data to fzf")?;
+
+        let out = child.wait_with_output().context("Failed to wait for fzf")?;
+
+        let text = match out.status.code() {
+            Some(0) | Some(1) | Some(2) => {
+                String::from_utf8(out.stdout).context("Invalid utf8 received from fzf")?
+            }
+            Some(130) => process::exit(130),
+            _ => {
+                let err = String::from_utf8(out.stderr)
+                    .unwrap_or_else(|_| "<stderr contains invalid UTF-8>".to_owned());
+                panic!("External command failed:\n {}", err)
+            }
+        };
+
+        let out = get_column(
+            parse_output_single(text, opts.suggestion_type)?,
+            opts.column,
+            opts.delimiter.as_deref(),
+        );
+
+        Ok((out, result_map))
+    }
 }

--- a/src/finder/mod.rs
+++ b/src/finder/mod.rs
@@ -1,10 +1,17 @@
-use crate::display;
-use crate::structures::cheat::VariableMap;
-use crate::structures::fzf::{Opts, SuggestionType};
+#[cfg(not(feature = "use_skim"))]
+mod fzf;
+#[cfg(feature = "use_skim")]
+mod skim;
+
+#[cfg(not(feature = "use_skim"))]
+pub use fzf::call;
+
+#[cfg(feature = "use_skim")]
+pub use skim::call;
+
+use crate::structures::finder::SuggestionType;
 use anyhow::Context;
 use anyhow::Error;
-use std::process;
-use std::process::{Command, Stdio};
 
 fn get_column(text: String, column: Option<u8>, delimiter: Option<&str>) -> String {
     if let Some(c) = column {
@@ -24,125 +31,6 @@ fn get_column(text: String, column: Option<u8>, delimiter: Option<&str>) -> Stri
     } else {
         text
     }
-}
-
-pub fn call<F>(opts: Opts, stdin_fn: F) -> Result<(String, Option<VariableMap>), Error>
-where
-    F: Fn(&mut process::ChildStdin) -> Result<Option<VariableMap>, Error>,
-{
-    let mut fzf_command = Command::new("fzf");
-
-    fzf_command.args(&[
-        "--preview-window",
-        "up:2",
-        "--with-nth",
-        "1,2,3",
-        "--delimiter",
-        display::DELIMITER.to_string().as_str(),
-        "--ansi",
-        "--bind",
-        "ctrl-j:down,ctrl-k:up",
-        "--exact",
-    ]);
-
-    if opts.autoselect {
-        fzf_command.arg("--select-1");
-    }
-
-    match opts.suggestion_type {
-        SuggestionType::MultipleSelections => {
-            fzf_command.arg("--multi");
-        }
-        SuggestionType::Disabled => {
-            fzf_command.args(&["--print-query", "--no-select-1", "--height", "1"]);
-        }
-        SuggestionType::SnippetSelection => {
-            fzf_command.args(&["--expect", "ctrl-y,enter"]);
-        }
-        SuggestionType::SingleRecommendation => {
-            fzf_command.args(&["--print-query", "--expect", "tab,enter"]);
-        }
-        _ => {}
-    }
-
-    if let Some(p) = opts.preview {
-        fzf_command.args(&["--preview", &p]);
-    }
-
-    if let Some(q) = opts.query {
-        fzf_command.args(&["--query", &q]);
-    }
-
-    if let Some(f) = opts.filter {
-        fzf_command.args(&["--filter", &f]);
-    }
-
-    if let Some(h) = opts.header {
-        fzf_command.args(&["--header", &h]);
-    }
-
-    if let Some(p) = opts.prompt {
-        fzf_command.args(&["--prompt", &p]);
-    }
-
-    if let Some(pw) = opts.preview_window {
-        fzf_command.args(&["--preview-window", &pw]);
-    }
-
-    if opts.header_lines > 0 {
-        fzf_command.args(&["--header-lines", format!("{}", opts.header_lines).as_str()]);
-    }
-
-    if let Some(o) = opts.overrides {
-        o.as_str()
-            .split(' ')
-            .map(|s| s.to_string())
-            .filter(|s| !s.is_empty())
-            .for_each(|s| {
-                fzf_command.arg(s);
-            });
-    }
-
-    let child = fzf_command
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .spawn();
-
-    let mut child = match child {
-        Ok(x) => x,
-        Err(_) => {
-            eprintln!("navi was unable to call fzf.\nPlease make sure it's correctly installed\nRefer to https://github.com/junegunn/fzf for more info.");
-            process::exit(33)
-        }
-    };
-
-    let stdin = child
-        .stdin
-        .as_mut()
-        .ok_or_else(|| anyhow!("Unable to acquire stdin of fzf"))?;
-    let result_map = stdin_fn(stdin).context("Failed to pass data to fzf")?;
-
-    let out = child.wait_with_output().context("Failed to wait for fzf")?;
-
-    let text = match out.status.code() {
-        Some(0) | Some(1) | Some(2) => {
-            String::from_utf8(out.stdout).context("Invalid utf8 received from fzf")?
-        }
-        Some(130) => process::exit(130),
-        _ => {
-            let err = String::from_utf8(out.stderr)
-                .unwrap_or_else(|_| "<stderr contains invalid UTF-8>".to_owned());
-            panic!("External command failed:\n {}", err)
-        }
-    };
-
-    let out = get_column(
-        parse_output_single(text, opts.suggestion_type)?,
-        opts.column,
-        opts.delimiter.as_deref(),
-    );
-
-    Ok((out, result_map))
 }
 
 fn parse_output_single(mut text: String, suggestion_type: SuggestionType) -> Result<String, Error> {

--- a/src/finder/skim.rs
+++ b/src/finder/skim.rs
@@ -1,4 +1,4 @@
-use super::{get_column, parse_output_single};
+use super::{get_column, parse_output_single, Finder};
 use crate::display;
 use crate::structures::cheat::VariableMap;
 use crate::structures::finder::{Opts, SuggestionType};
@@ -7,125 +7,130 @@ use anyhow::Error;
 use std::process;
 use std::process::{Command, Stdio};
 
-pub fn call<F>(opts: Opts, stdin_fn: F) -> Result<(String, Option<VariableMap>), Error>
-where
-    F: Fn(&mut process::ChildStdin) -> Result<Option<VariableMap>, Error>,
-{
-    let mut skim_command = Command::new("sk");
+#[derive(Debug)]
+pub struct SkimFinder;
 
-    skim_command.args(&[
-        "--preview-window",
-        "up:2",
-        "--with-nth",
-        "1,2,3",
-        "--delimiter",
-        display::DELIMITER.to_string().as_str(),
-        "--ansi",
-        "--bind",
-        "ctrl-j:down,ctrl-k:up",
-        "--exact",
-    ]);
+impl Finder for SkimFinder {
+    fn call<F>(&self, opts: Opts, stdin_fn: F) -> Result<(String, Option<VariableMap>), Error>
+    where
+        F: Fn(&mut process::ChildStdin) -> Result<Option<VariableMap>, Error>,
+    {
+        let mut skim_command = Command::new("sk");
 
-    if opts.autoselect {
-        // TODO skim doesn't support this yet
-        // this option does nothing
-        skim_command.arg("--select-1");
-    }
+        skim_command.args(&[
+            "--preview-window",
+            "up:2",
+            "--with-nth",
+            "1,2,3",
+            "--delimiter",
+            display::DELIMITER.to_string().as_str(),
+            "--ansi",
+            "--bind",
+            "ctrl-j:down,ctrl-k:up",
+            "--exact",
+        ]);
 
-    match opts.suggestion_type {
-        SuggestionType::MultipleSelections => {
-            skim_command.arg("--multi");
+        if opts.autoselect {
+            // TODO skim doesn't support this yet
+            // this option does nothing
+            skim_command.arg("--select-1");
         }
-        SuggestionType::Disabled => {
-            skim_command.args(&["--print-query", /*"--no-select-1",*/ "--height", "1"]);
+
+        match opts.suggestion_type {
+            SuggestionType::MultipleSelections => {
+                skim_command.arg("--multi");
+            }
+            SuggestionType::Disabled => {
+                skim_command.args(&["--print-query", /*"--no-select-1",*/ "--height", "1"]);
+            }
+            SuggestionType::SnippetSelection => {
+                skim_command.args(&["--expect", "ctrl-y,enter"]);
+            }
+            SuggestionType::SingleRecommendation => {
+                skim_command.args(&["--print-query", "--expect", "tab,enter"]);
+            }
+            _ => {}
         }
-        SuggestionType::SnippetSelection => {
-            skim_command.args(&["--expect", "ctrl-y,enter"]);
+
+        if let Some(p) = opts.preview {
+            skim_command.args(&["--preview", &p]);
         }
-        SuggestionType::SingleRecommendation => {
-            skim_command.args(&["--print-query", "--expect", "tab,enter"]);
+
+        if let Some(q) = opts.query {
+            skim_command.args(&["--query", &q]);
         }
-        _ => {}
-    }
 
-    if let Some(p) = opts.preview {
-        skim_command.args(&["--preview", &p]);
-    }
-
-    if let Some(q) = opts.query {
-        skim_command.args(&["--query", &q]);
-    }
-
-    if let Some(f) = opts.filter {
-        skim_command.args(&["--filter", &f]);
-    }
-
-    if let Some(h) = opts.header {
-        skim_command.args(&["--header", &h]);
-    }
-
-    if let Some(p) = opts.prompt {
-        skim_command.args(&["--prompt", &p]);
-    }
-
-    if let Some(pw) = opts.preview_window {
-        skim_command.args(&["--preview-window", &pw]);
-    }
-
-    if opts.header_lines > 0 {
-        skim_command.args(&["--header-lines", format!("{}", opts.header_lines).as_str()]);
-    }
-
-    if let Some(o) = opts.overrides {
-        o.as_str()
-            .split(' ')
-            .map(|s| s.to_string())
-            .filter(|s| !s.is_empty())
-            .for_each(|s| {
-                skim_command.arg(s);
-            });
-    }
-
-    let child = skim_command
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .spawn();
-
-    let mut child = match child {
-        Ok(x) => x,
-        Err(_) => {
-            eprintln!("navi was unable to call skim.\nPlease make sure it's correctly installed\nRefer to https://github.com/junegunn/skim for more info.");
-            process::exit(33)
+        if let Some(f) = opts.filter {
+            skim_command.args(&["--filter", &f]);
         }
-    };
 
-    let stdin = child
-        .stdin
-        .as_mut()
-        .ok_or_else(|| anyhow!("Unable to acquire stdin of skim"))?;
-    let result_map = stdin_fn(stdin).context("Failed to pass data to skim")?;
-
-    let out = child
-        .wait_with_output()
-        .context("Failed to wait for skim")?;
-
-    let text = match out.status.code() {
-        Some(0) | Some(1) | Some(2) => {
-            String::from_utf8(out.stdout).context("Invalid utf8 received from skim")?
+        if let Some(h) = opts.header {
+            skim_command.args(&["--header", &h]);
         }
-        Some(130) => process::exit(130),
-        _ => {
-            let err = String::from_utf8(out.stderr)
-                .unwrap_or_else(|_| "<stderr contains invalid UTF-8>".to_owned());
-            panic!("External command failed:\n {}", err)
+
+        if let Some(p) = opts.prompt {
+            skim_command.args(&["--prompt", &p]);
         }
-    };
 
-    let out = get_column(
-        parse_output_single(text, opts.suggestion_type)?,
-        opts.column,
-        opts.delimiter.as_deref(),
-    );
+        if let Some(pw) = opts.preview_window {
+            skim_command.args(&["--preview-window", &pw]);
+        }
 
-    Ok((out, result_map))
+        if opts.header_lines > 0 {
+            skim_command.args(&["--header-lines", format!("{}", opts.header_lines).as_str()]);
+        }
+
+        if let Some(o) = opts.overrides {
+            o.as_str()
+                .split(' ')
+                .map(|s| s.to_string())
+                .filter(|s| !s.is_empty())
+                .for_each(|s| {
+                    skim_command.arg(s);
+                });
+        }
+
+        let child = skim_command
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn();
+
+        let mut child = match child {
+            Ok(x) => x,
+            Err(_) => {
+                eprintln!("navi was unable to call skim.\nPlease make sure it's correctly installed\nRefer to https://github.com/junegunn/skim for more info.");
+                process::exit(33)
+            }
+        };
+
+        let stdin = child
+            .stdin
+            .as_mut()
+            .ok_or_else(|| anyhow!("Unable to acquire stdin of skim"))?;
+        let result_map = stdin_fn(stdin).context("Failed to pass data to skim")?;
+
+        let out = child
+            .wait_with_output()
+            .context("Failed to wait for skim")?;
+
+        let text = match out.status.code() {
+            Some(0) | Some(1) | Some(2) => {
+                String::from_utf8(out.stdout).context("Invalid utf8 received from skim")?
+            }
+            Some(130) => process::exit(130),
+            _ => {
+                let err = String::from_utf8(out.stderr)
+                    .unwrap_or_else(|_| "<stderr contains invalid UTF-8>".to_owned());
+                panic!("External command failed:\n {}", err)
+            }
+        };
+
+        let out = get_column(
+            parse_output_single(text, opts.suggestion_type)?,
+            opts.column,
+            opts.delimiter.as_deref(),
+        );
+
+        Ok((out, result_map))
+    }
 }

--- a/src/finder/skim.rs
+++ b/src/finder/skim.rs
@@ -1,0 +1,131 @@
+use super::{get_column, parse_output_single};
+use crate::display;
+use crate::structures::cheat::VariableMap;
+use crate::structures::finder::{Opts, SuggestionType};
+use anyhow::Context;
+use anyhow::Error;
+use std::process;
+use std::process::{Command, Stdio};
+
+pub fn call<F>(opts: Opts, stdin_fn: F) -> Result<(String, Option<VariableMap>), Error>
+where
+    F: Fn(&mut process::ChildStdin) -> Result<Option<VariableMap>, Error>,
+{
+    let mut skim_command = Command::new("sk");
+
+    skim_command.args(&[
+        "--preview-window",
+        "up:2",
+        "--with-nth",
+        "1,2,3",
+        "--delimiter",
+        display::DELIMITER.to_string().as_str(),
+        "--ansi",
+        "--bind",
+        "ctrl-j:down,ctrl-k:up",
+        "--exact",
+    ]);
+
+    if opts.autoselect {
+        // TODO skim doesn't support this yet
+        // this option does nothing
+        skim_command.arg("--select-1");
+    }
+
+    match opts.suggestion_type {
+        SuggestionType::MultipleSelections => {
+            skim_command.arg("--multi");
+        }
+        SuggestionType::Disabled => {
+            skim_command.args(&["--print-query", /*"--no-select-1",*/ "--height", "1"]);
+        }
+        SuggestionType::SnippetSelection => {
+            skim_command.args(&["--expect", "ctrl-y,enter"]);
+        }
+        SuggestionType::SingleRecommendation => {
+            skim_command.args(&["--print-query", "--expect", "tab,enter"]);
+        }
+        _ => {}
+    }
+
+    if let Some(p) = opts.preview {
+        skim_command.args(&["--preview", &p]);
+    }
+
+    if let Some(q) = opts.query {
+        skim_command.args(&["--query", &q]);
+    }
+
+    if let Some(f) = opts.filter {
+        skim_command.args(&["--filter", &f]);
+    }
+
+    if let Some(h) = opts.header {
+        skim_command.args(&["--header", &h]);
+    }
+
+    if let Some(p) = opts.prompt {
+        skim_command.args(&["--prompt", &p]);
+    }
+
+    if let Some(pw) = opts.preview_window {
+        skim_command.args(&["--preview-window", &pw]);
+    }
+
+    if opts.header_lines > 0 {
+        skim_command.args(&["--header-lines", format!("{}", opts.header_lines).as_str()]);
+    }
+
+    if let Some(o) = opts.overrides {
+        o.as_str()
+            .split(' ')
+            .map(|s| s.to_string())
+            .filter(|s| !s.is_empty())
+            .for_each(|s| {
+                skim_command.arg(s);
+            });
+    }
+
+    let child = skim_command
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn();
+
+    let mut child = match child {
+        Ok(x) => x,
+        Err(_) => {
+            eprintln!("navi was unable to call skim.\nPlease make sure it's correctly installed\nRefer to https://github.com/junegunn/skim for more info.");
+            process::exit(33)
+        }
+    };
+
+    let stdin = child
+        .stdin
+        .as_mut()
+        .ok_or_else(|| anyhow!("Unable to acquire stdin of skim"))?;
+    let result_map = stdin_fn(stdin).context("Failed to pass data to skim")?;
+
+    let out = child
+        .wait_with_output()
+        .context("Failed to wait for skim")?;
+
+    let text = match out.status.code() {
+        Some(0) | Some(1) | Some(2) => {
+            String::from_utf8(out.stdout).context("Invalid utf8 received from skim")?
+        }
+        Some(130) => process::exit(130),
+        _ => {
+            let err = String::from_utf8(out.stderr)
+                .unwrap_or_else(|_| "<stderr contains invalid UTF-8>".to_owned());
+            panic!("External command failed:\n {}", err)
+        }
+    };
+
+    let out = get_column(
+        parse_output_single(text, opts.suggestion_type)?,
+        opts.column,
+        opts.delimiter.as_deref(),
+    );
+
+    Ok((out, result_map))
+}

--- a/src/flows/core.rs
+++ b/src/flows/core.rs
@@ -1,11 +1,11 @@
 use crate::display;
 use crate::filesystem;
+use crate::finder;
 use crate::flows;
-use crate::fzf;
 use crate::handler;
 use crate::parser;
 use crate::structures::cheat::{Suggestion, VariableMap};
-use crate::structures::fzf::{Opts as FzfOpts, SuggestionType};
+use crate::structures::finder::{Opts as FinderOpts, SuggestionType};
 use crate::structures::option;
 use crate::structures::{error::command::BashSpawnError, option::Config};
 use anyhow::Context;
@@ -26,15 +26,15 @@ pub enum Variant {
     Query(String),
 }
 
-fn gen_core_fzf_opts(variant: Variant, config: &Config) -> Result<FzfOpts, Error> {
-    let mut opts = FzfOpts {
+fn gen_core_finder_opts(variant: Variant, config: &Config) -> Result<FinderOpts, Error> {
+    let mut opts = FinderOpts {
         preview: if config.no_preview {
             None
         } else {
             Some(format!("{} preview {{}}", filesystem::exe_string()?))
         },
         autoselect: !config.no_autoselect,
-        overrides: config.fzf_overrides.clone(),
+        overrides: config.finder_overrides.clone(),
         suggestion_type: SuggestionType::SnippetSelection,
         ..Default::default()
     };
@@ -100,34 +100,34 @@ fn prompt_with_suggestions(
     .context("Suggestions are invalid utf8")?;
 
     let opts = suggestion_opts.clone().unwrap_or_default();
-    let opts = FzfOpts {
+    let opts = FinderOpts {
         autoselect: !config.no_autoselect,
-        overrides: config.fzf_overrides_var.clone(),
+        overrides: config.finder_overrides_var.clone(),
         prompt: Some(display::variable_prompt(varname)),
         ..opts
     };
 
-    let (output, _) = fzf::call(opts, |stdin| {
+    let (output, _) = finder::call(opts, |stdin| {
         stdin
             .write_all(suggestions.as_bytes())
-            .context("Could not write to fzf's stdin")?;
+            .context("Could not write to finder's stdin")?;
         Ok(None)
     })
-    .context("fzf was unable to prompt with suggestions")?;
+    .context("finder was unable to prompt with suggestions")?;
 
     Ok(output)
 }
 
 fn prompt_without_suggestions(variable_name: &str) -> Result<String, Error> {
-    let opts = FzfOpts {
+    let opts = FinderOpts {
         autoselect: false,
         prompt: Some(display::variable_prompt(variable_name)),
         suggestion_type: SuggestionType::Disabled,
         ..Default::default()
     };
 
-    let (output, _) = fzf::call(opts, |_stdin| Ok(None))
-        .context("fzf was unable to prompt without suggestions")?;
+    let (output, _) = finder::call(opts, |_stdin| Ok(None))
+        .context("finder was unable to prompt without suggestions")?;
 
     Ok(output)
 }
@@ -175,14 +175,14 @@ fn with_new_lines(txt: String) -> String {
 pub fn main(variant: Variant, config: Config, contains_key: bool) -> Result<(), Error> {
     let _ = display::WIDTHS;
 
-    let opts = gen_core_fzf_opts(variant, &config).context("Failed to generate fzf options")?;
-    let (raw_selection, variables) = fzf::call(opts, |stdin| {
-        Ok(Some(
-            parser::read_all(&config, stdin)
-                .context("Failed to parse variables intended for fzf")?,
-        ))
+    let opts =
+        gen_core_finder_opts(variant, &config).context("Failed to generate finder options")?;
+    let (raw_selection, variables) = finder::call(opts, |stdin| {
+        Ok(Some(parser::read_all(&config, stdin).context(
+            "Failed to parse variables intended for finder",
+        )?))
     })
-    .context("Failed getting selection and variables from fzf")?;
+    .context("Failed getting selection and variables from finder")?;
 
     let (key, tags, snippet) = extract_from_selections(&raw_selection[..], contains_key);
 
@@ -190,7 +190,7 @@ pub fn main(variant: Variant, config: Config, contains_key: bool) -> Result<(), 
         replace_variables_from_snippet(
             snippet,
             tags,
-            variables.expect("No variables received from fzf"),
+            variables.expect("No variables received from finder"),
             &config,
         )
         .context("Failed to replace variables from snippet")?,
@@ -205,7 +205,7 @@ pub fn main(variant: Variant, config: Config, contains_key: bool) -> Result<(), 
     // save to file
     } else if let Some(s) = config.save {
         fs::write(s, interpolated_snippet).context("Unable to save config")?;
-    // call navi (this prevents "failed to read /dev/tty" from fzf)
+    // call navi (this prevents "failed to read /dev/tty" from finder)
     } else if interpolated_snippet.starts_with("navi") {
         let new_config = option::config_from_iter(interpolated_snippet.split(' ').collect());
         handler::handle_config(new_config)?;

--- a/src/flows/repo.rs
+++ b/src/flows/repo.rs
@@ -1,7 +1,7 @@
 use crate::filesystem;
-use crate::fzf;
+use crate::finder;
 use crate::git;
-use crate::structures::fzf::{Opts as FzfOpts, SuggestionType};
+use crate::structures::finder::{Opts as FinderOpts, SuggestionType};
 use anyhow::Context;
 use anyhow::Error;
 use git2::Repository;
@@ -25,18 +25,18 @@ pub fn browse() -> Result<(), Error> {
     let repos = fs::read_to_string(format!("{}/featured_repos.txt", &repo_path_str))
         .context("Unable to fetch featured repositories")?;
 
-    let opts = FzfOpts {
+    let opts = FinderOpts {
         column: Some(1),
         ..Default::default()
     };
 
-    let (repo, _) = fzf::call(opts, |stdin| {
+    let (repo, _) = finder::call(opts, |stdin| {
         stdin
             .write_all(repos.as_bytes())
             .context("Unable to prompt featured repositories")?;
         Ok(None)
     })
-    .context("Failed to get repo URL from fzf")?;
+    .context("Failed to get repo URL from finder")?;
 
     filesystem::remove_dir(&repo_path_str)?;
 
@@ -67,7 +67,7 @@ pub fn add(uri: String) -> Result<(), Error> {
         .collect::<Vec<String>>()
         .join("\n");
 
-    let opts = FzfOpts {
+    let opts = FinderOpts {
         suggestion_type: SuggestionType::MultipleSelections,
         preview: Some(format!("cat '{}/{{}}'", tmp_path_str)),
         header: Some(
@@ -77,13 +77,13 @@ pub fn add(uri: String) -> Result<(), Error> {
         ..Default::default()
     };
 
-    let (files, _) = fzf::call(opts, |stdin| {
+    let (files, _) = finder::call(opts, |stdin| {
         stdin
             .write_all(all_files.as_bytes())
             .context("Unable to prompt cheats to import")?;
         Ok(None)
     })
-    .context("Failed to get cheatsheet files from fzf")?;
+    .context("Failed to get cheatsheet files from finder")?;
 
     for f in files.split('\n') {
         let from = format!("{}/{}", tmp_path_str, f).replace("./", "");

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -34,11 +34,10 @@ pub fn handle_config(config: Config) -> Result<(), Error> {
                 .with_context(|| format!("Failed to execute function `{}`", func)),
 
             Repo { cmd } => match cmd {
-                RepoCommand::Add { uri } => flows::repo::add(uri.clone())
+                RepoCommand::Add { uri } => flows::repo::add(uri.clone(), &config.finder)
                     .with_context(|| format!("Failed to import cheatsheets from `{}`", uri)),
-                RepoCommand::Browse => {
-                    flows::repo::browse().context("Failed to browse featured cheatsheets")
-                }
+                RepoCommand::Browse => flows::repo::browse(&config.finder)
+                    .context("Failed to browse featured cheatsheets"),
             },
         },
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,8 +5,8 @@ extern crate anyhow;
 
 mod display;
 mod filesystem;
+mod finder;
 mod flows;
-mod fzf;
 mod git;
 mod handler;
 mod parser;

--- a/src/structures/cheat.rs
+++ b/src/structures/cheat.rs
@@ -1,5 +1,5 @@
+use crate::structures::finder::Opts;
 use crate::structures::fnv::HashLine;
-use crate::structures::fzf::Opts;
 use std::collections::HashMap;
 
 pub type Suggestion = (String, Option<Opts>);

--- a/src/structures/finder.rs
+++ b/src/structures/finder.rs
@@ -35,13 +35,13 @@ impl Default for Opts {
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum SuggestionType {
-    /// fzf will not print any suggestions
+    /// finder will not print any suggestions
     Disabled,
-    /// fzf will only select one of the suggestions
+    /// finder will only select one of the suggestions
     SingleSelection,
-    /// fzf will select multiple suggestions
+    /// finder will select multiple suggestions
     MultipleSelections,
-    /// fzf will select one of the suggestions or use the query
+    /// finder will select one of the suggestions or use the query
     SingleRecommendation,
     /// initial snippet selection
     SnippetSelection,

--- a/src/structures/mod.rs
+++ b/src/structures/mod.rs
@@ -1,5 +1,5 @@
 pub mod cheat;
 pub mod error;
 pub mod fnv;
-pub mod fzf;
+pub mod finder;
 pub mod option;

--- a/src/structures/option.rs
+++ b/src/structures/option.rs
@@ -1,4 +1,14 @@
+use crate::finder::FinderChoice;
+use anyhow::Error;
 use structopt::{clap::AppSettings, StructOpt};
+
+fn parse_finder(src: &str) -> Result<FinderChoice, Error> {
+    match src {
+        "fzf" => Ok(FinderChoice::Fzf),
+        "skim" => Ok(FinderChoice::Skim),
+        _ => Err(Error::msg(format!("unknown finder '{}'", src))),
+    }
+}
 
 #[derive(Debug, StructOpt)]
 #[structopt(after_help = r#"EXAMPLES:
@@ -10,6 +20,7 @@ use structopt::{clap::AppSettings, StructOpt};
     navi best 'sql create db' root mydb    # uses a snippet as a CLI
     navi repo add denisidoro/cheats        # imports cheats from github.com/denisidoro/cheats
     source <(navi widget zsh)              # loads the zsh widget
+    navi --finder 'skim'                   # set which finder is supposed to be used (fzf [default] / skim)
     navi --fzf-overrides ' --with-nth 1,2' # shows only the comment and tag columns
     navi --fzf-overrides ' --nth 1,2'      # search will consider only the first two columns
     navi --fzf-overrides ' --no-exact'     # looser search algorithm"#)]
@@ -39,11 +50,15 @@ pub struct Config {
 
     /// finder overrides for cheat selection
     #[structopt(long, env = "NAVI_FZF_OVERRIDES")]
-    pub finder_overrides: Option<String>,
+    pub fzf_overrides: Option<String>,
 
     /// finder overrides for variable selection
     #[structopt(long, env = "NAVI_FZF_OVERRIDES_VAR")]
-    pub finder_overrides_var: Option<String>,
+    pub fzf_overrides_var: Option<String>,
+
+    /// finder overrides for variable selection
+    #[structopt(long, env = "NAVI_FINDER", default_value = "fzf", parse(try_from_str = parse_finder))]
+    pub finder: FinderChoice,
 
     #[structopt(subcommand)]
     pub cmd: Option<Command>,

--- a/src/structures/option.rs
+++ b/src/structures/option.rs
@@ -37,13 +37,13 @@ pub struct Config {
     #[structopt(long)]
     pub no_preview: bool,
 
-    /// FZF overrides for cheat selection
-    #[structopt(long, env = "NAVI_FZF_OVERRIDES")]
-    pub fzf_overrides: Option<String>,
+    /// finder overrides for cheat selection
+    #[structopt(long, env = "NAVI_FINDER_OVERRIDES")]
+    pub finder_overrides: Option<String>,
 
-    /// FZF overrides for variable selection
-    #[structopt(long, env = "NAVI_FZF_OVERRIDES_VAR")]
-    pub fzf_overrides_var: Option<String>,
+    /// finder overrides for variable selection
+    #[structopt(long, env = "NAVI_FINDER_OVERRIDES_VAR")]
+    pub finder_overrides_var: Option<String>,
 
     #[structopt(subcommand)]
     pub cmd: Option<Command>,

--- a/src/structures/option.rs
+++ b/src/structures/option.rs
@@ -38,11 +38,11 @@ pub struct Config {
     pub no_preview: bool,
 
     /// finder overrides for cheat selection
-    #[structopt(long, env = "NAVI_FINDER_OVERRIDES")]
+    #[structopt(long, env = "NAVI_FZF_OVERRIDES")]
     pub finder_overrides: Option<String>,
 
     /// finder overrides for variable selection
-    #[structopt(long, env = "NAVI_FINDER_OVERRIDES_VAR")]
+    #[structopt(long, env = "NAVI_FZF_OVERRIDES_VAR")]
     pub finder_overrides_var: Option<String>,
 
     #[structopt(subcommand)]


### PR DESCRIPTION
* added a compile time feature `use_skim` which causes that `sk` binary is used instead of `fzf`.
* refactored some code to be more `fzf/skim` neutral.

related issue #227 