### PR TITLE
use zle redisplay

### DIFF
--- a/shell/navi.plugin.zsh
+++ b/shell/navi.plugin.zsh
@@ -1,10 +1,11 @@
 #!/usr/bin/env zsh
 
 _call_navi() {
-   local -r buff="$BUFFER"
-   local -r r="$(printf "$(navi --print </dev/tty)")"
-   zle kill-whole-line
-   zle -U "${buff}${r}"
+  local selected
+  if selected="$(printf "$(navi --print </dev/tty)")"; then
+    LBUFFER="$selected"
+  fi
+  zle redisplay
 }
 
 zle -N _call_navi


### PR DESCRIPTION
The original behavior:
1. The whole line in terminal will be killed
2. The new command will be printed one character by one character

The new behavior:
1. The selected command will be printed on terminal directly.

The code is based on <https://github.com/junegunn/fzf/wiki/examples#locate>.