### PR TITLE
Use what's already typed on the commandline as a filter

### DIFF
--- a/shell/navi.plugin.zsh
+++ b/shell/navi.plugin.zsh
@@ -3,7 +3,7 @@
 _call_navi() {
   local selected
   if [ -n "$LBUFFER" ]; then
-    if selected="$(printf "%s" "$(navi --print query "${LBUFFER}" </dev/tty)")"; then
+    if selected="$(printf "%s" "$(navi --print --no-autoselect query "${LBUFFER}" </dev/tty)")"; then
       LBUFFER="$selected"
     fi
   else

--- a/shell/navi.plugin.zsh
+++ b/shell/navi.plugin.zsh
@@ -2,8 +2,14 @@
 
 _call_navi() {
   local selected
-  if selected="$(printf "%s" "$(navi --print </dev/tty)")"; then
-    LBUFFER="$selected"
+  if [ -n "$LBUFFER" ]; then
+    if selected="$(printf "%s" "$(navi --print query "${LBUFFER}" </dev/tty)")"; then
+      LBUFFER="$selected"
+    fi
+  else
+    if selected="$(printf "%s" "$(navi --print </dev/tty)")"; then
+      LBUFFER="$selected"
+    fi
   fi
   zle redisplay
 }


### PR DESCRIPTION
This lets me type part of a command in ZSH and then press ^G to have navi filter on the already typed command.