### PR TITLE
Do not use deprecated args, commands.

### DIFF
--- a/shell/navi.plugin.bash
+++ b/shell/navi.plugin.bash
@@ -4,7 +4,7 @@ _call_navi() {
     local selected
 
     if [ -n "${READLINE_LINE}" ]; then
-        if selected="$(printf "%s" "$(navi --print --no-autoselect query "${READLINE_LINE}" </dev/tty)")"; then
+        if selected="$(printf "%s" "$(navi --print --fzf-overrides '--no-select-1' --query "${READLINE_LINE}" </dev/tty)")"; then
             READLINE_LINE="$selected"
             READLINE_POINT=${#READLINE_LINE}
         fi

--- a/shell/navi.plugin.zsh
+++ b/shell/navi.plugin.zsh
@@ -3,7 +3,7 @@
 _call_navi() {
   local selected
   if [ -n "$LBUFFER" ]; then
-    if selected="$(printf "%s" "$(navi --print --no-autoselect query "${LBUFFER}" </dev/tty)")"; then
+    if selected="$(printf "%s" "$(navi --print --fzf-overrides '--no-select-1' --query "${LBUFFER}" </dev/tty)")"; then
       LBUFFER="$selected"
     fi
   else


### PR DESCRIPTION
Using deprecated args (`--no-autoselect`, `query`) leads to annoying warning when using shell widget.