### PR TITLE
Allow configuration of shell used for shell out

### DIFF
--- a/src/actor.rs
+++ b/src/actor.rs
@@ -13,7 +13,7 @@ use anyhow::Context;
 use anyhow::Error;
 use std::io::Write;
 use std::path::Path;
-use std::process::{Command, Stdio};
+use std::process::Stdio;
 
 fn prompt_finder(
     variable_name: &str,

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -1,18 +1,16 @@
 use crate::clipboard;
 use crate::env_var;
 use crate::extractor;
-use crate::writer;
-
 use crate::finder::structures::{Opts as FinderOpts, SuggestionType};
 use crate::finder::Finder;
-use crate::shell::{BashSpawnError, IS_FISH};
+use crate::shell;
+use crate::shell::{ShellSpawnError, IS_FISH};
 use crate::structures::cheat::{Suggestion, VariableMap};
 use crate::structures::config::Action;
 use crate::structures::config::Config;
-
+use crate::writer;
 use anyhow::Context;
 use anyhow::Error;
-
 use std::io::Write;
 use std::path::Path;
 use std::process::{Command, Stdio};
@@ -47,12 +45,12 @@ fn prompt_finder(
             }
         }
 
-        let child = Command::new("bash")
+        let child = shell::command()
             .stdout(Stdio::piped())
             .arg("-c")
             .arg(&suggestion_command)
             .spawn()
-            .map_err(|e| BashSpawnError::new(suggestion_command, e))?;
+            .map_err(|e| ShellSpawnError::new(suggestion_command, e))?;
 
         let text = String::from_utf8(
             child
@@ -211,11 +209,11 @@ pub fn act(
                 clipboard::copy(interpolated_snippet)?;
             }
             _ => {
-                Command::new("bash")
+                shell::command()
                     .arg("-c")
                     .arg(&interpolated_snippet[..])
                     .spawn()
-                    .map_err(|e| BashSpawnError::new(&interpolated_snippet[..], e))?
+                    .map_err(|e| ShellSpawnError::new(&interpolated_snippet[..], e))?
                     .wait()
                     .context("bash was not running")?;
             }

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -1,6 +1,5 @@
 use crate::shell::{self, ShellSpawnError};
 use anyhow::Error;
-use std::process::Command;
 
 pub fn copy(text: String) -> Result<(), Error> {
     let cmd = r#"

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -1,4 +1,4 @@
-use crate::shell::BashSpawnError;
+use crate::shell::{self, ShellSpawnError};
 use anyhow::Error;
 use std::process::Command;
 
@@ -20,7 +20,7 @@ _copy() {
    fi
 }"#;
 
-    Command::new("bash")
+    shell::command()
         .arg("-c")
         .arg(
             format!(
@@ -35,7 +35,7 @@ echo -n "$x" | _copy"#,
             .as_str(),
         )
         .spawn()
-        .map_err(|e| BashSpawnError::new(cmd, e))?
+        .map_err(|e| ShellSpawnError::new(cmd, e))?
         .wait()?;
 
     Ok(())

--- a/src/cmds/func.rs
+++ b/src/cmds/func.rs
@@ -1,5 +1,5 @@
 use crate::handler;
-use crate::shell::BashSpawnError;
+use crate::shell::{self, ShellSpawnError};
 use crate::structures::config;
 use crate::url;
 use anyhow::Error;
@@ -27,11 +27,11 @@ pub fn main(func: &Func, args: Vec<String>) -> Result<(), Error> {
 
 fn map_expand() -> Result<(), Error> {
     let cmd = r#"sed -e 's/^.*$/"&"/' | tr '\n' ' '"#;
-    Command::new("bash")
+    shell::command()
         .arg("-c")
         .arg(cmd)
         .spawn()
-        .map_err(|e| BashSpawnError::new(cmd, e))?
+        .map_err(|e| ShellSpawnError::new(cmd, e))?
         .wait()?;
     Ok(())
 }

--- a/src/cmds/func.rs
+++ b/src/cmds/func.rs
@@ -4,7 +4,6 @@ use crate::structures::config;
 use crate::url;
 use anyhow::Error;
 use std::io::{self, Read};
-use std::process::Command;
 
 #[derive(Debug)]
 pub enum Func {

--- a/src/env_var.rs
+++ b/src/env_var.rs
@@ -23,6 +23,8 @@ pub const FZF_OVERRIDES: &str = "NAVI_FZF_OVERRIDES";
 pub const FZF_OVERRIDES_VAR: &str = "NAVI_FZF_OVERRIDES_VAR";
 pub const FINDER: &str = "NAVI_FINDER";
 
+pub const SHELL: &str = "NAVI_SHELL";
+
 pub fn parse<T: FromStr>(varname: &str) -> Option<T> {
     if let Ok(x) = env::var(varname) {
         x.parse::<T>().ok()

--- a/src/finder/post.rs
+++ b/src/finder/post.rs
@@ -2,7 +2,7 @@ use crate::finder::structures::SuggestionType;
 use crate::shell;
 use anyhow::Context;
 use anyhow::Error;
-use std::process::{Command, Stdio};
+use std::process::Stdio;
 
 fn apply_map(text: String, map_fn: Option<String>) -> Result<String, Error> {
     if let Some(m) = map_fn {

--- a/src/finder/post.rs
+++ b/src/finder/post.rs
@@ -1,8 +1,7 @@
 use crate::finder::structures::SuggestionType;
-
+use crate::shell;
 use anyhow::Context;
 use anyhow::Error;
-
 use std::process::{Command, Stdio};
 
 fn apply_map(text: String, map_fn: Option<String>) -> Result<String, Error> {
@@ -21,7 +20,7 @@ echo "$_navi_input" | _navi_map_fn"#,
             m, text
         );
 
-        let output = Command::new("bash")
+        let output = shell::command()
             .arg("-c")
             .arg(cmd.as_str())
             .stderr(Stdio::inherit())

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,4 +1,4 @@
-use crate::shell::BashSpawnError;
+use crate::shell::ShellSpawnError;
 use anyhow::{Context, Error};
 use std::process::Command;
 
@@ -6,7 +6,7 @@ pub fn shallow_clone(uri: &str, target: &str) -> Result<(), Error> {
     Command::new("git")
         .args(&["clone", uri, target, "--depth", "1"])
         .spawn()
-        .map_err(|e| BashSpawnError::new("git clone", e))?
+        .map_err(|e| ShellSpawnError::new("git clone", e))?
         .wait()
         .context("Unable to git clone")?;
     Ok(())

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -1,11 +1,13 @@
 use crate::env_var;
 use std::fmt::Debug;
+use std::process::Command;
 use thiserror::Error;
 
 lazy_static! {
     pub static ref IS_FISH: bool = env_var::get("SHELL")
         .unwrap_or_else(|_| "".to_string())
         .contains(&"fish");
+    static ref SHELL: String = env_var::get(env_var::SHELL).unwrap_or_else(|_| "bash".to_string());
 }
 
 #[derive(Debug)]
@@ -17,20 +19,24 @@ pub enum Shell {
 
 #[derive(Error, Debug)]
 #[error("Failed to spawn child process `bash` to execute `{command}`")]
-pub struct BashSpawnError {
+pub struct ShellSpawnError {
     command: String,
     #[source]
     source: anyhow::Error,
 }
 
-impl BashSpawnError {
+impl ShellSpawnError {
     pub fn new<SourceError>(command: impl Into<String>, source: SourceError) -> Self
     where
         SourceError: std::error::Error + Sync + Send + 'static,
     {
-        BashSpawnError {
+        ShellSpawnError {
             command: command.into(),
             source: source.into(),
         }
     }
+}
+
+pub fn command() -> Command {
+    Command::new(&*SHELL)
 }

--- a/src/url.rs
+++ b/src/url.rs
@@ -1,4 +1,4 @@
-use crate::shell::BashSpawnError;
+use crate::shell::{self, ShellSpawnError};
 use anyhow::Error;
 use std::process::Command;
 
@@ -32,11 +32,11 @@ NAVIEOF
 _open_url "$url""#,
         code, url
     );
-    Command::new("bash")
+    shell::command()
         .arg("-c")
         .arg(cmd.as_str())
         .spawn()
-        .map_err(|e| BashSpawnError::new(cmd, e))?
+        .map_err(|e| ShellSpawnError::new(cmd, e))?
         .wait()?;
     Ok(())
 }

--- a/src/url.rs
+++ b/src/url.rs
@@ -1,6 +1,5 @@
 use crate::shell::{self, ShellSpawnError};
 use anyhow::Error;
-use std::process::Command;
 
 pub fn open(args: Vec<String>) -> Result<(), Error> {
     let url = args


### PR DESCRIPTION
```
Benchmark #1: echo -e 'foo bar\nlorem ipsum' | NAVI_SHELL=dash navi fn map::expand
  Time (mean ± σ):      17.7 ms ±   4.8 ms    [User: 3.6 ms, System: 10.2 ms]
  Range (min … max):    10.9 ms …  38.1 ms    91 runs
 
Benchmark #1: echo -e 'foo bar\nlorem ipsum' | NAVI_SHELL=bash navi fn map::expand
  Time (mean ± σ):      22.0 ms ±   4.6 ms    [User: 5.2 ms, System: 7.9 ms]
  Range (min … max):    14.7 ms …  37.6 ms    88 runs
 
Benchmark #1: echo -e 'foo bar\nlorem ipsum' | NAVI_SHELL=sh navi fn map::expand
  Time (mean ± σ):      25.6 ms ±   5.5 ms    [User: 4.6 ms, System: 13.1 ms]
  Range (min … max):    17.6 ms …  40.3 ms    77 runs
 
Benchmark #1: echo -e 'foo bar\nlorem ipsum' | NAVI_SHELL=fish navi fn map::expand
  Time (mean ± σ):      26.0 ms ±   4.9 ms    [User: 8.0 ms, System: 9.4 ms]
  Range (min … max):    18.1 ms …  37.0 ms    86 runs
  ```