### PR TITLE
updates clap to v3.0-beta.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,9 +54,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "3.0.0-beta.2"
+version = "3.0.0-beta.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd1061998a501ee7d4b6d449020df3266ca3124b941ec56cf2005c3779ca142"
+checksum = "feff3878564edb93745d58cf63e17b63f24142506e7a20c87a5521ed7bfb1d63"
 dependencies = [
  "atty",
  "bitflags",
@@ -67,15 +67,14 @@ dependencies = [
  "strsim",
  "termcolor",
  "textwrap",
- "unicode-width",
- "vec_map",
+ "unicase",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.0.0-beta.2"
+version = "3.0.0-beta.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "370f715b81112975b1b69db93e0b56ea4cd4e5002ac43b2da8474106a54096a1"
+checksum = "8b15c6b4f786ffb6192ffe65a36855bc1fc2444bcd0945ae16748dcd6ed7d0d3"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -364,9 +363,12 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "2.4.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afb2e1c3ee07430c2cf76151675e583e0f19985fa6efae47d6848a3e2c824f85"
+checksum = "addaa943333a514159c80c97ff4a93306530d965d27e139188283cd13e06a799"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "parking_lot"
@@ -425,9 +427,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.27"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
+checksum = "edc3358ebc67bc8b7fa0c007f945b0b18226f78437d61bec735a9eb96b61ee70"
 dependencies = [
  "unicode-xid",
 ]
@@ -674,9 +676,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.73"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f71489ff30030d2ae598524f61326b902466f72a0fb1a8564c001cc63425bcc7"
+checksum = "d010a1623fbd906d51d650a9916aaefc05ffa0e4053ff7fe601167f3e715d194"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -708,9 +710,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.12.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "203008d98caf094106cfaba70acfed15e18ed3ddb7d94e49baec153a2b462789"
+checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
 dependencies = [
  "unicode-width",
 ]
@@ -736,6 +738,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicase"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -758,12 +769,6 @@ name = "utf8parse"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "936e4b492acfd135421d8dca4b1aa80a7bfc26e702ef3af710e0752684df5372"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ travis-ci = { repository = "denisidoro/navi", branch = "master" }
 
 [dependencies]
 regex = { version = "1.5.4", default-features = false, features = ["std", "unicode-perl"] }
-clap = "3.0.0-beta.2"
+clap = "3.0.0-beta.5"
 crossterm = "0.21.0"
 lazy_static = "1.4.0"
 directories-next = "2.0.0"

--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -4,7 +4,7 @@ use crate::handler::func::Func;
 use crate::handler::info::Info;
 use crate::shell::Shell;
 
-use clap::{crate_version, AppSettings, Clap};
+use clap::{crate_version, AppSettings, Parser, Subcommand};
 
 use std::str::FromStr;
 
@@ -55,7 +55,7 @@ impl FromStr for Info {
     }
 }
 
-#[derive(Debug, Clap)]
+#[derive(Debug, Parser)]
 #[clap(after_help = "\x1b[0;33mMORE INFO:\x1b[0;0m
     Please refer to \x1b[0;32mhttps://github.com/denisidoro/navi\x1b[0;0m
 
@@ -89,8 +89,6 @@ impl FromStr for Info {
     navi --fzf-overrides '--nth 1,2'             # only consider the first two columns for search
     navi --fzf-overrides '--no-exact'            # use looser search algorithm
     navi --tag-rules='git,!checkout'             # show non-checkout git snippets only")]
-#[clap(setting = AppSettings::ColorAuto)]
-#[clap(setting = AppSettings::ColoredHelp)]
 #[clap(setting = AppSettings::AllowLeadingHyphen)]
 #[clap(version = crate_version!())]
 pub(super) struct ClapConfig {
@@ -144,13 +142,9 @@ impl ClapConfig {
     }
 }
 
-#[derive(Debug, Clap)]
-#[clap(setting = AppSettings::ColorAuto)]
-#[clap(setting = AppSettings::ColoredHelp)]
+#[derive(Debug, Parser)]
 pub enum Command {
     /// [Experimental] Calls internal functions
-    #[clap(setting = AppSettings::ColorAuto)]
-    #[clap(setting = AppSettings::ColoredHelp)]
     Fn {
         /// Function name (example: "url::open")
         #[clap(possible_values = FUNC_POSSIBLE_VALUES, case_insensitive = true)]
@@ -159,24 +153,18 @@ pub enum Command {
         args: Vec<String>,
     },
     /// Manages cheatsheet repositories
-    #[clap(setting = AppSettings::ColorAuto)]
-    #[clap(setting = AppSettings::ColoredHelp)]
     Repo {
         #[clap(subcommand)]
         cmd: RepoCommand,
     },
     /// Used for fzf's preview window when selecting snippets
     #[clap(setting = AppSettings::Hidden)]
-    #[clap(setting = AppSettings::ColorAuto)]
-    #[clap(setting = AppSettings::ColoredHelp)]
     Preview {
         /// Selection line
         line: String,
     },
     /// Used for fzf's preview window when selecting variable suggestions
     #[clap(setting = AppSettings::Hidden)]
-    #[clap(setting = AppSettings::ColorAuto)]
-    #[clap(setting = AppSettings::ColoredHelp)]
     PreviewVar {
         /// Selection line
         selection: String,
@@ -187,28 +175,20 @@ pub enum Command {
     },
     /// Used for fzf's preview window when selecting variable suggestions
     #[clap(setting = AppSettings::Hidden)]
-    #[clap(setting = AppSettings::ColorAuto)]
-    #[clap(setting = AppSettings::ColoredHelp)]
     PreviewVarStdin,
     /// Outputs shell widget source code
-    #[clap(setting = AppSettings::ColorAuto)]
-    #[clap(setting = AppSettings::ColoredHelp)]
     Widget {
         #[clap(possible_values = WIDGET_POSSIBLE_VALUES, case_insensitive = true, default_value = "bash")]
         shell: Shell,
     },
     /// Shows info
-    #[clap(setting = AppSettings::ColorAuto)]
-    #[clap(setting = AppSettings::ColoredHelp)]
     Info {
         #[clap(possible_values = INFO_POSSIBLE_VALUES, case_insensitive = true)]
         info: Info,
     },
 }
 
-#[derive(Debug, Clap)]
-#[clap(setting = AppSettings::ColorAuto)]
-#[clap(setting = AppSettings::ColoredHelp)]
+#[derive(Debug, Subcommand)]
 pub enum RepoCommand {
     /// Imports cheatsheets from a repo
     Add {


### PR DESCRIPTION
The trait `Clap` was renamed to `Parser` and `ColorHelp::Auto` is the default.

This PR should replace #632 