### PR TITLE
Update legacy syntax from Elvish widget

### DIFF
--- a/shell/navi.plugin.elv
+++ b/shell/navi.plugin.elv
@@ -1,31 +1,29 @@
 use str
 
-fn call-navi []{
+fn call-navi {
   if (eq $edit:current-command '') {
-    answer = (navi --print)
+    var answer = (navi --print)
     edit:replace-input $answer
   } elif (not (str:contains-any $edit:current-command '|')) {
-    answer = (navi --print --query $edit:current-command)
+    var answer = (navi --print --query $edit:current-command)
     if (not-eq $answer '') {
       edit:replace-input $answer
     }
   } else {
-    cmds = [(str:split '|' $edit:current-command)]
-    qty = (- (count $cmds) 1)
-    query = (all $cmds | drop $qty)
-    cmds = [(all $cmds | take $qty)]
-    answer = ''
-    if (eq $query '') {
-      answer = (navi --print)
-    } else {
-      answer = (navi --print --query $query)
-    }
+    var @cmds query = (str:split '|' $edit:current-command)
+    var answer = (
+      if (eq $query '') {
+        navi --print
+      } else {
+        navi --print --query $query
+      }
+    )
 
     if (not-eq $answer '') {
-      cmds = [$@cmds $answer]
+      set cmds = [$@cmds $answer]
       edit:replace-input (str:join '| ' $cmds)
     }
   }
 }
 
-edit:insert:binding[Alt-h] = []{ call-navi >/dev/tty 2>&1 }
+set edit:insert:binding[Alt-h] = { call-navi >/dev/tty 2>&1 }


### PR DESCRIPTION
This PR updates the following legacy syntax from the Elvish widget so it works on v0.17 without deprecation errors:

- assignment: `foo = bar` → `var foo = bar` or `set foo = bar`
- lambdas: `[arg1 arg2]{ body }` → `{|arg1 arg2| body }`; all the lambdas in the widget have no arguments so they can simply be written as `{ body }` instead of `{|| body }` which coincidentally keeps the widget compatible with pre-0.17 versions

This PR also refactors some of the code so it's cleaner.

---

As the `var` and `set` special commands were introduced in Elvish v0.15 (January 2021), this updated Elvish widget will only work in versions 0.15 and up, so this PR is technically a breaking change.