### PR TITLE
Improve fish widget code

### DIFF
--- a/shell/navi.plugin.fish
+++ b/shell/navi.plugin.fish
@@ -1,43 +1,25 @@
-function __call_navi
-    navi --print
-end 
-
-function navi-widget -d "Show cheat sheets"
-  begin
-    set ttysettings (stty -g)
-    stty sane
-    __call_navi | perl -pe 'chomp if eof' | read -lz result
-    and commandline -- $result
-
-    stty $ttysettings
-  end
-  commandline -f repaint
-end
-
-# set -g navi_last_cmd ""
-
-function smart_replace
+function _navi_smart_replace
   set -l current_process (commandline -p)
 
-  if [ $current_process = "" ]
+  if test $current_process = ""
     commandline -p (navi --print)
     commandline -f repaint
   else
     set -l best_match (navi --print --best-match --query $current_process)
 
-    if not [ $best_match > /dev/null ];
+    if not test $best_match > /dev/null
       commandline -p $current_process
       commandline -f repaint
       return
     end
 
-    if [ $best_match = "" ]
+    if test $best_match = ""
         commandline -p (navi --print --query $current_process)
         commandline -f repaint
-    else if [ $current_process != $best_match ]
+    else if test $current_process != $best_match
       commandline -p $best_match
       commandline -f repaint
-    else if [ $current_process = $best_match ]
+    else
       commandline -p (navi --print --query $current_process)
       commandline -f repaint
     end
@@ -45,6 +27,4 @@ function smart_replace
 end
 
 bind \cg smart_replace
-if bind -M insert > /dev/null 2>&1
-  bind -M insert \cg smart_replace
-end
+bind -M insert \cg smart_replace

--- a/shell/navi.plugin.fish
+++ b/shell/navi.plugin.fish
@@ -26,5 +26,5 @@ function _navi_smart_replace
   end
 end
 
-bind \cg smart_replace
-bind -M insert \cg smart_replace
+bind \cg _navi_smart_replace
+bind -M insert \cg _navi_smart_replace

--- a/shell/navi.plugin.fish
+++ b/shell/navi.plugin.fish
@@ -11,11 +11,11 @@ function _navi_smart_replace
         end
 
         if test -z "$best_match"
-            commandline -p (navi --print --query $current_process)
+            commandline -p (navi --print --query "$current_process")
         else if test "$current_process" != "$best_match"
             commandline -p $best_match
         else
-            commandline -p (navi --print --query $current_process)
+            commandline -p (navi --print --query "$current_process")
         end
     end
 

--- a/shell/navi.plugin.fish
+++ b/shell/navi.plugin.fish
@@ -1,18 +1,18 @@
 function _navi_smart_replace
     set -l current_process (commandline -p | string trim)
 
-    if test -z $current_process
+    if test -z "$current_process"
         commandline -i (navi --print)
     else
-        set -l best_match (navi --print --best-match --query $current_process)
+        set -l best_match (navi --print --best-match --query "$current_process")
 
-        if not test $best_match >/dev/null
+        if not test "$best_match" >/dev/null
             return
         end
 
-        if test $best_match = ""
+        if test -z "$best_match"
             commandline -p (navi --print --query $current_process)
-        else if test $current_process != $best_match
+        else if test "$current_process" != "$best_match"
             commandline -p $best_match
         else
             commandline -p (navi --print --query $current_process)

--- a/shell/navi.plugin.fish
+++ b/shell/navi.plugin.fish
@@ -22,5 +22,8 @@ function _navi_smart_replace
   commandline -f repaint
 end
 
-bind \cg _navi_smart_replace
-bind -M insert \cg _navi_smart_replace
+if test $fish_key_bindings = fish_default_key_bindings
+  bind \cg _navi_smart_replace
+else
+  bind -M insert \cg _navi_smart_replace
+end

--- a/shell/navi.plugin.fish
+++ b/shell/navi.plugin.fish
@@ -1,5 +1,5 @@
 function _navi_smart_replace
-  set -l current_process (commandline -p)
+  set -l current_process (commandline -p | string trim)
 
   if test $current_process = ""
     commandline -p (navi --print)

--- a/shell/navi.plugin.fish
+++ b/shell/navi.plugin.fish
@@ -1,29 +1,29 @@
 function _navi_smart_replace
-  set -l current_process (commandline -p | string trim)
+    set -l current_process (commandline -p | string trim)
 
-  if test -z $current_process
-    commandline -i (navi --print)
-  else
-    set -l best_match (navi --print --best-match --query $current_process)
-
-    if not test $best_match > /dev/null
-      return
-    end
-
-    if test $best_match = ""
-      commandline -p (navi --print --query $current_process)
-    else if test $current_process != $best_match
-      commandline -p $best_match
+    if test -z $current_process
+        commandline -i (navi --print)
     else
-      commandline -p (navi --print --query $current_process)
-    end
-  end
+        set -l best_match (navi --print --best-match --query $current_process)
 
-  commandline -f repaint
+        if not test $best_match >/dev/null
+            return
+        end
+
+        if test $best_match = ""
+            commandline -p (navi --print --query $current_process)
+        else if test $current_process != $best_match
+            commandline -p $best_match
+        else
+            commandline -p (navi --print --query $current_process)
+        end
+    end
+
+    commandline -f repaint
 end
 
 if test $fish_key_bindings = fish_default_key_bindings
-  bind \cg _navi_smart_replace
+    bind \cg _navi_smart_replace
 else
-  bind -M insert \cg _navi_smart_replace
+    bind -M insert \cg _navi_smart_replace
 end

--- a/shell/navi.plugin.fish
+++ b/shell/navi.plugin.fish
@@ -1,29 +1,25 @@
 function _navi_smart_replace
   set -l current_process (commandline -p | string trim)
 
-  if test $current_process = ""
-    commandline -p (navi --print)
-    commandline -f repaint
+  if test -z $current_process
+    commandline -i (navi --print)
   else
     set -l best_match (navi --print --best-match --query $current_process)
 
     if not test $best_match > /dev/null
-      commandline -p $current_process
-      commandline -f repaint
       return
     end
 
     if test $best_match = ""
-        commandline -p (navi --print --query $current_process)
-        commandline -f repaint
+      commandline -p (navi --print --query $current_process)
     else if test $current_process != $best_match
       commandline -p $best_match
-      commandline -f repaint
     else
       commandline -p (navi --print --query $current_process)
-      commandline -f repaint
     end
   end
+
+  commandline -f repaint
 end
 
 bind \cg _navi_smart_replace


### PR DESCRIPTION
- Remove unused code
- Replace `[` with idiomatic `test`. fish's manpage says:

  > The first form (**test**) is preferred. For compatibility with other shells, the
  > second form is available: a matching pair of square brackets (**[ [EXPRESSION ] ]**).

- Prepend underscore to widget function to avoid name clashing
- Insert command instead of replacing, when not doing smart replace
- Only bind insert mode when not using default keybindings
- Correctly quote variables to support multiline commands