### PR TITLE
Add build feature to disable command execution

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ keywords = ["cheatsheets", "terminal", "cli", "tui", "shell"]
 categories = ["command-line-utilities"]
 license = "Apache-2.0"
 
+[features]
+disable-command-execution = []
+
 [badges]
 travis-ci = { repository = "denisidoro/navi", branch = "master" }
 

--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -97,6 +97,7 @@ pub(super) struct ClapConfig {
 
     /// Instead of executing a snippet, prints it to stdout
     #[clap(long)]
+    #[cfg(not(feature = "disable-command-execution"))]
     pub print: bool,
 
     /// Returns the best match

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -136,8 +136,18 @@ impl Config {
         self.yaml.style.comment.min_width
     }
 
+    #[cfg(feature = "disable-command-execution")]
+    fn print(&self) -> bool {
+        true
+    }
+
+    #[cfg(not(feature = "disable-command-execution"))]
+    fn print(&self) -> bool {
+        self.clap.print
+    }
+
     pub fn action(&self) -> Action {
-        if self.clap.print {
+        if self.print() {
             Action::Print
         } else {
             Action::Execute


### PR DESCRIPTION
This CL adds the build feature `disable-command-execution` that enforces the `--print` flag and thereby disables execution of commands. Basically `--print` is enforced and cannot be disabled.

I think this proposed change will make `navi` usable in a wider range of situations, especially when a single execution can have far reaching impacts. Think: operations.

**Rationale:**
`navi` is great, because it allows users, who are not deeply familiar with a tooling, to still use it at an expert level: The underlying cheatsheets are persisted, combined knowledge; the variables add environment state. Both together make it a powerful idea.
Going back to above scenarios, in which a single keystroke can have great consequences: Extra care of executing the generated commands should be taken. This extra care is far more likely to take place when a manual component is involved, i.e: if you have to copy & paste the command and then execute it yourself, you are more likely to take responsibility and therefore care.

I understand, that `navi` also makes great sense in other scenarios where this additional care is not needed / wanted, hence the proposal of a build flag, to make this tool available to either one.
