### PR TITLE
Add build feature to disable repo management

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ license = "Apache-2.0"
 
 [features]
 disable-command-execution = []
+disable-repo-management = []
 
 [badges]
 travis-ci = { repository = "denisidoro/navi", branch = "master" }

--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -153,6 +153,7 @@ pub enum Command {
         args: Vec<String>,
     },
     /// Manages cheatsheet repositories
+    #[cfg(not(feature = "disable-repo-management"))]
     Repo {
         #[clap(subcommand)]
         cmd: RepoCommand,

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -8,7 +8,9 @@ pub mod repo_add;
 pub mod repo_browse;
 pub mod shell;
 
-use crate::config::Command::{Fn, Info, Preview, PreviewVar, PreviewVarStdin, Repo, Widget};
+#[cfg(not(feature = "disable-repo-management"))]
+use crate::config::Command::Repo;
+use crate::config::Command::{Fn, Info, Preview, PreviewVar, PreviewVarStdin, Widget};
 use crate::config::{RepoCommand, CONFIG};
 use crate::handler;
 use anyhow::Context;
@@ -38,6 +40,7 @@ pub fn handle() -> Result<()> {
                 handler::info::main(info).with_context(|| format!("Failed to fetch info `{:#?}`", info))
             }
 
+            #[cfg(not(feature = "disable-repo-management"))]
             Repo { cmd } => match cmd {
                 RepoCommand::Add { uri } => {
                     handler::repo_add::main(uri.clone())


### PR DESCRIPTION
Having a command to install cheatsheets from repositories on github is amazing and makes `navi` very easy to setup and get started. The repo contents provide the "meat" of `navi`. A one-liner can load a bunch of useful cheatsheets for a whole host of open source commands.

However, in locked down environments, where a high level of control of what is executed needs to be imposed, having the capability to download and use "arbitrary code from the internet" can be more harmful than good. Here you would likely want to manage all cheathsheets for `navi` carefully yourself. Possibly reviewing each cheathsheet individually. This CL provides a build feature that disables the whole `repo` sub-command tree to support that use-case.