### PR TITLE
Make width configurable for snippet column

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -128,12 +128,20 @@ impl Config {
         self.yaml.style.comment.width_percentage
     }
 
+    pub fn snippet_width_percentage(&self) -> u16 {
+        self.yaml.style.snippet.width_percentage
+    }
+
     pub fn tag_min_width(&self) -> u16 {
         self.yaml.style.tag.min_width
     }
 
     pub fn comment_min_width(&self) -> u16 {
         self.yaml.style.comment.min_width
+    }
+
+    pub fn snippet_min_width(&self) -> u16 {
+        self.yaml.style.snippet.min_width
     }
 
     #[cfg(feature = "disable-command-execution")]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -3,7 +3,7 @@ use crate::terminal;
 pub use crate::terminal::style::style;
 use std::cmp::max;
 
-pub fn get_widths() -> (usize, usize) {
+pub fn get_widths() -> (usize, usize, usize) {
     let width = terminal::width();
     let tag_width_percentage = max(
         CONFIG.tag_min_width(),
@@ -13,8 +13,13 @@ pub fn get_widths() -> (usize, usize) {
         CONFIG.comment_min_width(),
         width * CONFIG.comment_width_percentage() / 100,
     );
+    let snippet_width_percentage = max(
+        CONFIG.snippet_min_width(),
+        width * CONFIG.snippet_width_percentage() / 100,
+    );
     (
         usize::from(tag_width_percentage),
         usize::from(comment_width_percentage),
+        usize::from(snippet_width_percentage),
     )
 }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -11,7 +11,7 @@ pub const DELIMITER: &str = r"  ⠀";
 lazy_static! {
     pub static ref NEWLINE_REGEX: Regex = Regex::new(r"\\\s+").expect("Invalid regex");
     pub static ref VAR_REGEX: Regex = Regex::new(r"\\?<(\w[\w\d\-_]*)>").expect("Invalid regex");
-    pub static ref COLUMN_WIDTHS: (usize, usize) = ui::get_widths();
+    pub static ref COLUMN_WIDTHS: (usize, usize, usize) = ui::get_widths();
 }
 
 pub fn with_new_lines(txt: String) -> String {
@@ -37,12 +37,12 @@ fn limit_str(text: &str, length: usize) -> String {
 }
 
 pub fn write(item: &Item) -> String {
-    let (tag_width_percentage, comment_width_percentage) = *COLUMN_WIDTHS;
+    let (tag_width_percentage, comment_width_percentage, snippet_width_percentage) = *COLUMN_WIDTHS;
     format!(
             "{tags_short}{delimiter}{comment_short}{delimiter}{snippet_short}{delimiter}{tags}{delimiter}{comment}{delimiter}{snippet}{delimiter}{file_index}{delimiter}\n",
             tags_short = ui::style(limit_str(&item.tags, tag_width_percentage)).with(CONFIG.tag_color()),
             comment_short = ui::style(limit_str(&item.comment, comment_width_percentage)).with(CONFIG.comment_color()),
-            snippet_short = ui::style(fix_newlines(&item.snippet)).with(CONFIG.snippet_color()),
+            snippet_short = ui::style(limit_str(&fix_newlines(&item.snippet), snippet_width_percentage)).with(CONFIG.snippet_color()),
             tags = item.tags,
             comment = item.comment,
             delimiter = DELIMITER,


### PR DESCRIPTION
Even though the options 'width_percentage' and 'width_min' were allowed
in the config.yaml file for all three columns (tag, comment, snippet),
they were not actually parsed for the snippet column. This patch makes
these settings work.

Fixes #696 