### PR TITLE
Fix preview map "leaking" with multiple variables

### DIFF
--- a/src/commands/preview/var.rs
+++ b/src/commands/preview/var.rs
@@ -90,8 +90,14 @@ impl Runnable for Input {
                 "{variables}\n{variable} = {value}",
                 variables = variables,
                 variable = style(variable_name).with(variable_color),
-                value = finder::process(value, column, delimiter.as_deref(), map.clone())
-                    .expect("Unable to process value"),
+                value = if env_var::get(&env_variable_name).is_ok() {
+                    value
+                } else if is_current {
+                    finder::process(value, column, delimiter.as_deref(), map.clone())
+                            .expect("Unable to process value")
+                } else {
+                    "".to_string()
+                }
             );
         }
 


### PR DESCRIPTION
With multiple variables in the preview, each with
different «--map» options, there is an application
of the map code for the current variable to the
preview of the other variables as well.
This code fixes that.

The problem is limited only to the preview.

NOTE: @denisidoro this is my first time handling rust code, so any correction is welcome.