### PR TITLE
Fix typos

### DIFF
--- a/src/finder/post.rs
+++ b/src/finder/post.rs
@@ -157,8 +157,8 @@ mod tests {
 
     #[test]
     fn test_parse_snippet_request() {
-        let text = "enter\nssh                     ⠀login to a server and forward to ssh key (d…  ⠀ssh -A <user>@<server>  ⠀ssh  ⠀login to a server and forward to ssh key (dangerous but usefull for bastion hosts)  ⠀ssh -A <user>@<server>  ⠀\n".to_string();
+        let text = "enter\nssh                     ⠀login to a server and forward to ssh key (d…  ⠀ssh -A <user>@<server>  ⠀ssh  ⠀login to a server and forward to ssh key (dangerous but useful for bastion hosts)  ⠀ssh -A <user>@<server>  ⠀\n".to_string();
         let output = parse_output_single(text, SuggestionType::SnippetSelection).unwrap();
-        assert_eq!(output,     "enter\nssh                     ⠀login to a server and forward to ssh key (d…  ⠀ssh -A <user>@<server>  ⠀ssh  ⠀login to a server and forward to ssh key (dangerous but usefull for bastion hosts)  ⠀ssh -A <user>@<server>  ⠀");
+        assert_eq!(output,     "enter\nssh                     ⠀login to a server and forward to ssh key (d…  ⠀ssh -A <user>@<server>  ⠀ssh  ⠀login to a server and forward to ssh key (dangerous but useful for bastion hosts)  ⠀ssh -A <user>@<server>  ⠀");
     }
 }

--- a/tests/no_prompt_cheats/cases.cheat
+++ b/tests/no_prompt_cheats/cases.cheat
@@ -101,5 +101,5 @@ $ wallpaper_folder: echo "<pictures_folder>/wallpapers"
 
 % test, third
 
-; this cheathsheet doesnt have any commands
+; this cheathsheet doesn't have any commands
 $ country: echo "br"


### PR DESCRIPTION
Found via `codespell -L crate,ser`