### PR TITLE
Fix install script

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -279,10 +279,10 @@ install_navi() {
    log::success "navi is now available at ${navi_bin_path}"
    echoerr
 
-   if echo "$PATH" | grep -q "$navi_bin_path"; then
+   if echo "$PATH" | grep -q "$navi_bin_dir"; then
       :
    else
-      local -r cmd="$(export_path_cmd "$navi_bin_path")"
+      local -r cmd="$(export_path_cmd "$navi_bin_dir")"
       append_to_file "${HOME}/.bashrc" "$cmd"
       append_to_file "${ZDOTDIR:-"$HOME"}/.zshrc" "$cmd"
       append_to_file "${HOME}/.fishrc" "$cmd"
@@ -292,7 +292,7 @@ install_navi() {
    echo
    log::note "Check https://github.com/denisidoro/navi for more info"
 
-   export PATH="${PATH}:${navi_bin_path}"
+   export PATH="${PATH}:${navi_bin_dir}"
 
    return 0
 }


### PR DESCRIPTION
Thanks for publishing such a useful tool!

I'm trying to install to use `navi`.
However, `$PATH` is note properly added when `navi` is installed [using install script](https://github.com/denisidoro/navi/blob/master/docs/installation.md#using-install-script) as below.

```bash
root@64873fa233a0:/# bash <(curl -sL https://raw.githubusercontent.com/denisidoro/navi/master/scripts/install)
Downloading https://github.com/denisidoro/navi/releases/download/v2.20.1/navi-v2.20.1-x86_64-unknown-linux-musl.tar.gz...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 2005k  100 2005k    0     0  2208k      0 --:--:-- --:--:-- --:--:-- 9505k
navi

✔ Finished
✔ navi is now available at /root/.cargo/bin/navi

To call navi, restart your shell or reload your .bashrc-like config file

Check https://github.com/denisidoro/navi for more info
root@64873fa233a0:/# ls /root/.cargo/bin/
navi
root@64873fa233a0:/# source ~/.bashrc 
root@64873fa233a0:/# navi --help
bash: navi: command not found
```

I think that some `$navi_bin_path` in the install script need to be replaced with `$navi_bin_dir`.
(`$navi_bin_dir` is defined but is never used now.)