### PR TITLE
Handle multiline snippets better

### DIFF
--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -18,7 +18,7 @@ pub fn all_cheat_files(path: &Path) -> Vec<String> {
         .into_iter()
         .filter_map(|e| e.ok())
         .map(|e| e.path().to_str().unwrap_or("").to_string())
-        .filter(|e| e.ends_with(".cheat"))
+        .filter(|e| e.ends_with(".cheat") || e.ends_with(".cheat.md"))
         .collect::<Vec<String>>()
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -243,6 +243,8 @@ impl<'a> Parser<'a> {
 
         let mut variable_cmd = String::from("");
 
+        let mut inside_snippet: bool = false;
+
         for (line_nr, line_result) in lines.enumerate() {
             let line = line_result
                 .with_context(|| format!("Failed to read line number {} in cheatsheet `{}`", line_nr, id))?;
@@ -284,7 +286,9 @@ impl<'a> Parser<'a> {
                 item.comment = without_prefix(&line);
             }
             // variable
-            else if !variable_cmd.is_empty() || (line.starts_with('$') && line.contains(':')) {
+            else if !variable_cmd.is_empty()
+                || (line.starts_with('$') && line.contains(':')) && !inside_snippet
+            {
                 should_break = self.write_cmd(&item).is_err();
 
                 item.snippet = String::from("");
@@ -305,6 +309,10 @@ impl<'a> Parser<'a> {
                     self.variables
                         .insert_suggestion(&item.tags, variable, (String::from(command), opts));
                 }
+            }
+            // markdown snippet
+            else if line.starts_with("```") {
+                inside_snippet = !inside_snippet;
             }
             // snippet
             else {


### PR DESCRIPTION
Add support for code blocks using markdown syntax. Lines that are part of the snippet and match the variables regex won't be interpeted as a variable.

Additionally, add `.cheat.md` as a file extension for cheats so that it can be rendered on GitHub with proper code formatting and syntax highlighting.

Fixes #806