### PR TITLE
Upgrade clap to `4.2.1`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "342258dd14006105c2b75ab1bd7543a03bdf0cfc94383303ac212a04939dff6f"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-wincon",
+ "concolor-override",
+ "concolor-query",
+ "is-terminal",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23ea9e81bd02e310c216d080f6223c179012256e5151c41db88d12c88a1684d2"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7d1bb534e9efed14f3e5f44e7dd1a4f709384023a4165199a4241e18dff0116"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3127af6145b149f3287bb9a0d10ad9c5692dba8c53ad48285e5bec4063834fa"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -22,17 +62,6 @@ name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
-]
 
 [[package]]
 name = "autocfg"
@@ -47,6 +76,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "cc"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -54,41 +89,60 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "3.2.14"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54635806b078b7925d6e36810b1755f2a4b5b4d57560432c1ecf60bcbe10602b"
+checksum = "046ae530c528f252094e4a77886ee1374437744b2bff1497aa898bbddbbb29b3"
 dependencies = [
- "atty",
- "bitflags",
+ "clap_builder",
  "clap_derive",
+ "once_cell",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "223163f58c9a40c3b0a43e1c4b50a9ce09f007ea2cb1ec258a687945b4b7929f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "bitflags",
  "clap_lex",
- "indexmap",
  "once_cell",
  "strsim",
- "termcolor",
- "textwrap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.2.7"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "759bf187376e1afa7b85b959e6a664a3e7a95203415dba952ad19139e798f902"
+checksum = "3f9644cd56d6b87dbe899ef8b053e331c0637664e9e21a33dfcdc36093f5c5c4"
 dependencies = [
  "heck",
- "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.13",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.2.2"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5538cd660450ebeb4234cfecf8f2284b844ffc4c50531e66d584ad5b91293613"
+checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
+
+[[package]]
+name = "concolor-override"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a855d4a1978dc52fb0536a04d384c2c0c1aa273597f08b77c8c4d3b2eec6037f"
+
+[[package]]
+name = "concolor-query"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d11d52c3d7ca2e6d0040212be9e4dbbcd78b6447f535b6b561f449427944cf"
 dependencies = [
- "os_str_bytes",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -198,6 +252,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
+name = "errno"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50d6a0976c999d473fe89ad888d5a284e55366d9dc9038b1ba2aa15128c4afa0"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -230,6 +305,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+
+[[package]]
 name = "indexmap"
 version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -240,6 +321,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-lifetimes"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09270fd4fa1111bc614ed2246c7ef56239a3063d5be0d1ec3b589c505d400aeb"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "libc",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "256017f749ab3117e93acb91063009e1f1bb56d03965b14c2c8df4eb02c524d8"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -247,15 +351,21 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.125"
+version = "0.2.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5916d2ae698f6de9bfb891ad7a8d65c09d232dc58cc4ac433c7da3b2fd84bc2b"
+checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
 
 [[package]]
 name = "linked-hash-map"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d59d8c75012853d2e872fb56bc8a2e53718e2cafe1a4c823143141c6d90c322f"
 
 [[package]]
 name = "lock_api"
@@ -328,7 +438,7 @@ version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.18",
  "libc",
 ]
 
@@ -337,12 +447,6 @@ name = "once_cell"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
-
-[[package]]
-name = "os_str_bytes"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
 
 [[package]]
 name = "parking_lot"
@@ -374,43 +478,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.38"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9027b48e9d4c9175fa2218adf3557f91c1137021739951d4932f5f8268ac48aa"
+checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.9"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
 ]
@@ -539,6 +619,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "0.37.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2aae838e49b3d63e9274e1c01833cc8139d3fec468c3b84688c628f44b1ae11d"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -576,7 +670,7 @@ checksum = "6f2122636b9fe3b81f1cb25099fcf2d3f542cdb1d45940d56c713158884a05da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.94",
 ]
 
 [[package]]
@@ -664,6 +758,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c9da457c5285ac1f936ebd076af6dac17a61cfe7826f2076b4d015cf47bc8ec"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -676,21 +781,6 @@ dependencies = [
  "remove_dir_all 0.5.3",
  "winapi",
 ]
-
-[[package]]
-name = "termcolor"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
@@ -709,8 +799,14 @@ checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.94",
 ]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
 
 [[package]]
 name = "unicode-xid"
@@ -720,15 +816,9 @@ checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "utf8parse"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936e4b492acfd135421d8dca4b1aa80a7bfc26e702ef3af710e0752684df5372"
-
-[[package]]
-name = "version_check"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "vte"
@@ -842,6 +932,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -852,6 +972,12 @@ name = "windows_aarch64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -866,6 +992,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -876,6 +1008,12 @@ name = "windows_i686_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -890,6 +1028,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -900,6 +1050,12 @@ name = "windows_x86_64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ travis-ci = { repository = "denisidoro/navi", branch = "master" }
 
 [dependencies]
 regex = { version = "1.6.0", default-features = false, features = ["std", "unicode-perl"] }
-clap = { version = "3.2.14", features = ["derive", "cargo"] }
+clap = { version = "4.2.1", features = ["derive", "cargo"] }
 crossterm = "0.24.0"
 lazy_static = "1.4.0"
 directories-next = "2.0.0"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.62.0"
+channel = "1.68.2"
 components = [ "rustfmt", "clippy" ]

--- a/src/commands/func/mod.rs
+++ b/src/commands/func/mod.rs
@@ -6,44 +6,26 @@ use super::temp;
 use crate::common::url;
 use crate::prelude::*;
 use clap::Args;
-use clap::Parser;
+use clap::ValueEnum;
 
-const POSSIBLE_VALUES: &[&str] = &[
-    "url::open",
-    "welcome",
-    "widget::last_command",
-    "map::expand",
-    "temp",
-];
-
-impl FromStr for Func {
-    type Err = &'static str;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "url::open" => Ok(Func::UrlOpen),
-            "welcome" => Ok(Func::Welcome),
-            "widget::last_command" => Ok(Func::WidgetLastCommand),
-            "map::expand" => Ok(Func::MapExpand),
-            "temp" => Ok(Func::Temp),
-            _ => Err("no match"),
-        }
-    }
-}
-
-#[derive(Debug, Clone, Parser)]
+#[derive(Debug, Clone, ValueEnum)]
 pub enum Func {
+    #[value(name = "url::open")]
     UrlOpen,
+    #[value(name = "welcome")]
     Welcome,
+    #[value(name = "widget::last_command")]
     WidgetLastCommand,
+    #[value(name = "map::expand")]
     MapExpand,
+    #[value(name = "temp")]
     Temp,
 }
 
 #[derive(Debug, Clone, Args)]
 pub struct Input {
     /// Function name (example: "url::open")
-    #[clap(possible_values = POSSIBLE_VALUES, ignore_case = true)]
+    #[arg(ignore_case = true)]
     pub func: Func,
     /// List of arguments (example: "https://google.com")
     pub args: Vec<String>,
@@ -61,12 +43,5 @@ impl Runnable for Input {
             Func::MapExpand => map::expand(),
             Func::Temp => temp::main(),
         }
-    }
-}
-
-#[test]
-fn test_possible_values() {
-    for v in POSSIBLE_VALUES {
-        assert!(Func::from_str(v).is_ok())
     }
 }

--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -1,31 +1,16 @@
 use clap::Args;
+use clap::ValueEnum;
 
 use crate::filesystem;
 use crate::prelude::*;
 
-const POSSIBLE_VALUES: &[&str] = &["cheats-example", "cheats-path", "config-path", "config-example"];
-
-impl FromStr for Info {
-    type Err = &'static str;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "cheats-example" => Ok(Info::CheatsExample),
-            "cheats-path" => Ok(Info::CheatsPath),
-            "config-example" => Ok(Info::ConfigExample),
-            "config-path" => Ok(Info::ConfigPath),
-            _ => Err("no match"),
-        }
-    }
-}
-
 #[derive(Debug, Clone, Args)]
 pub struct Input {
-    #[clap(possible_values = POSSIBLE_VALUES, ignore_case = true)]
+    #[arg(ignore_case = true)]
     pub info: Info,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, ValueEnum)]
 pub enum Info {
     CheatsExample,
     CheatsPath,
@@ -44,12 +29,5 @@ impl Runnable for Input {
             Info::ConfigExample => println!("{}", include_str!("../../docs/config_file_example.yaml")),
         }
         Ok(())
-    }
-}
-
-#[test]
-fn test_possible_values() {
-    for v in POSSIBLE_VALUES {
-        assert!(Info::from_str(v).is_ok())
     }
 }

--- a/src/commands/shell.rs
+++ b/src/commands/shell.rs
@@ -1,27 +1,27 @@
+use std::fmt;
+use std::fmt::Display;
+
 use clap::Args;
 
 use crate::common::shell::Shell;
 use crate::prelude::*;
 
-const POSSIBLE_VALUES: &[&str] = &["bash", "zsh", "fish", "elvish"];
+impl Display for Shell {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            Self::Bash => "bash",
+            Self::Zsh => "zsh",
+            Self::Fish => "fish",
+            Self::Elvish => "elvish",
+        };
 
-impl FromStr for Shell {
-    type Err = &'static str;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "bash" => Ok(Shell::Bash),
-            "zsh" => Ok(Shell::Zsh),
-            "fish" => Ok(Shell::Fish),
-            "elvish" => Ok(Shell::Elvish),
-            _ => Err("no match"),
-        }
+        write!(f, "{s}")
     }
 }
 
 #[derive(Debug, Clone, Args)]
 pub struct Input {
-    #[clap(possible_values = POSSIBLE_VALUES, ignore_case = true, default_value = "bash")]
+    #[clap(ignore_case = true, default_value_t = Shell::Bash)]
     pub shell: Shell,
 }
 
@@ -39,12 +39,5 @@ impl Runnable for Input {
         println!("{}", content);
 
         Ok(())
-    }
-}
-
-#[test]
-fn test_possible_values() {
-    for v in POSSIBLE_VALUES {
-        assert!(Shell::from_str(v).is_ok())
     }
 }

--- a/src/common/shell.rs
+++ b/src/common/shell.rs
@@ -1,10 +1,11 @@
 use crate::prelude::*;
+use clap::ValueEnum;
 use std::process::Command;
 use thiserror::Error;
 
 pub const EOF: &str = "NAVIEOF";
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, ValueEnum)]
 pub enum Shell {
     Bash,
     Zsh,

--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -1,10 +1,10 @@
 use crate::commands;
-use crate::finder::{self, FinderChoice};
+use crate::finder::FinderChoice;
 use crate::prelude::*;
-use clap::{crate_version, AppSettings, Parser, Subcommand};
+use clap::{crate_version, Parser, Subcommand};
 
 #[derive(Debug, Parser)]
-#[clap(after_help = "\x1b[0;33mMORE INFO:\x1b[0;0m
+#[command(after_help = "\x1b[0;33mMORE INFO:\x1b[0;0m
     Please refer to \x1b[0;32mhttps://github.com/denisidoro/navi\x1b[0;0m
 
 \x1b[0;33mENVIRONMENT VARIABLES:\x1b[0m
@@ -37,51 +37,50 @@ use clap::{crate_version, AppSettings, Parser, Subcommand};
     navi --fzf-overrides '--nth 1,2'             # only consider the first two columns for search
     navi --fzf-overrides '--no-exact'            # use looser search algorithm
     navi --tag-rules='git,!checkout'             # show non-checkout git snippets only")]
-#[clap(setting = AppSettings::AllowHyphenValues)]
 #[clap(version = crate_version!())]
 pub(super) struct ClapConfig {
     /// Colon-separated list of paths containing .cheat files
-    #[clap(short, long)]
+    #[arg(short, long)]
     pub path: Option<String>,
 
     /// Instead of executing a snippet, prints it to stdout
-    #[clap(long)]
+    #[arg(long)]
     #[cfg(not(feature = "disable-command-execution"))]
     pub print: bool,
 
     /// Returns the best match
-    #[clap(long)]
+    #[arg(long)]
     pub best_match: bool,
 
     /// Searches for cheatsheets using the tldr-pages repository
-    #[clap(long)]
+    #[arg(long)]
     pub tldr: Option<String>,
 
     /// [Experimental] Comma-separated list that acts as filter for tags. Parts starting with ! represent negation
-    #[clap(long)]
+    #[arg(long)]
     pub tag_rules: Option<String>,
 
     /// Searches for cheatsheets using the cheat.sh repository
-    #[clap(long)]
+    #[arg(long)]
     pub cheatsh: Option<String>,
 
     /// Prepopulates the search field
-    #[clap(short, long)]
+    #[arg(short, long, allow_hyphen_values = true)]
     pub query: Option<String>,
 
     /// Finder overrides for snippet selection
-    #[clap(long)]
+    #[arg(long, allow_hyphen_values = true)]
     pub fzf_overrides: Option<String>,
 
     /// Finder overrides for variable selection
-    #[clap(long)]
+    #[arg(long, allow_hyphen_values = true)]
     pub fzf_overrides_var: Option<String>,
 
     /// Finder application to use
-    #[clap(long, possible_values = finder::POSSIBLE_VALUES, ignore_case = true)]
+    #[arg(long, ignore_case = true)]
     pub finder: Option<FinderChoice>,
 
-    #[clap(subcommand)]
+    #[command(subcommand)]
     pub cmd: Option<Command>,
 }
 
@@ -100,13 +99,13 @@ pub enum Command {
     #[cfg(not(feature = "disable-repo-management"))]
     Repo(commands::repo::Input),
     /// Used for fzf's preview window when selecting snippets
-    #[clap(setting = AppSettings::Hidden)]
+    #[command(hide = true)]
     Preview(commands::preview::Input),
     /// Used for fzf's preview window when selecting variable suggestions
-    #[clap(setting = AppSettings::Hidden)]
+    #[command(hide = true)]
     PreviewVar(commands::preview::var::Input),
     /// Used for fzf's preview window when selecting variable suggestions
-    #[clap(setting = AppSettings::Hidden)]
+    #[command(hide = true)]
     PreviewVarStdin(commands::preview::var_stdin::Input),
     /// Outputs shell widget source code
     Widget(commands::shell::Input),

--- a/src/finder/mod.rs
+++ b/src/finder/mod.rs
@@ -4,19 +4,18 @@ use std::io::Write;
 use std::process::{self, Output};
 use std::process::{Command, Stdio};
 pub mod structures;
+use clap::ValueEnum;
 pub use post::process;
 use structures::Opts;
 use structures::SuggestionType;
 
 mod post;
 
-#[derive(Debug, Clone, Copy, Deserialize)]
+#[derive(Debug, Clone, Copy, Deserialize, ValueEnum)]
 pub enum FinderChoice {
     Fzf,
     Skim,
 }
-
-pub const POSSIBLE_VALUES: &[&str] = &["fzf", "skim"];
 
 impl FromStr for FinderChoice {
     type Err = &'static str;
@@ -188,12 +187,5 @@ impl FinderChoice {
 
         let output = parse(out, finder_opts).context("Unable to get output")?;
         Ok((output, return_value))
-    }
-}
-
-#[test]
-fn test_possible_values() {
-    for v in POSSIBLE_VALUES {
-        assert!(FinderChoice::from_str(v).is_ok())
     }
 }


### PR DESCRIPTION
I refactor the old clap code to `4.2.1` and the semantics remain the same. (I have checked manually and all the tests passed)

Using the latest clap requires **rustc** 1.64.0 or newer because of the error message `error: package `anstyle-parse v0.1.1` cannot be built because it requires rustc 1.64.0 or newer, while the currently active rustc version is 1.62.0` whose source package is dependence of clap. I recommend pinning rustc to `1.68.2` to use sparse index.