### PR TITLE
Add instructions for installing via pacman

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -27,6 +27,12 @@ Be sure to [enable](https://wiki.gentoo.org/wiki/Ebuild_repository) the [GURU ov
 emerge -a app-misc/navi
 ```
 
+#### Using [pacman](https://wiki.archlinux.org/title/Pacman)
+
+```sh
+pacman -S navi
+```
+
 #### Using [nix](https://nixos.org/)
 
 ```sh


### PR DESCRIPTION
`navi` is moved to the community repository: https://archlinux.org/packages/community/x86_64/navi/
