### PR TITLE
Use XDG conventions on macOS too

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,6 +282,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "etcetera"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51822eedc6129d8c4d96cec86d56b785e983f943c9ce9fb892e0c2a99a7f47a0"
+dependencies = [
+ "cfg-if",
+ "home",
+]
+
+[[package]]
 name = "fs_at"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -324,6 +334,15 @@ name = "hermit-abi"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+
+[[package]]
+name = "home"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "747309b4b440c06d57b0b25f2aee03ee9b5e5397d288c60e21fc709bb98a7408"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "indexmap"
@@ -434,10 +453,10 @@ dependencies = [
  "anyhow",
  "clap",
  "crossterm",
- "directories-next",
  "dns_common",
  "dns_common_derive",
  "edit",
+ "etcetera",
  "lazy_static",
  "regex",
  "remove_dir_all 0.8.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ regex = { version = "1.7.3", default-features = false, features = ["std", "unico
 clap = { version = "4.2.1", features = ["derive", "cargo"] }
 crossterm = "0.26.1"
 lazy_static = "1.4.0"
-directories-next = "2.0.0"
+etcetera = "0.7.1"
 walkdir = "2.3.3"
 shellwords = "1.1.0"
 anyhow = "1.0.70"


### PR DESCRIPTION
`~/Library/Application Support` is an utterly inconvenient location for macOS users. Most CLI tools follow the `XDG conventions` on macOS as well. Replace the `directories-next` crate with the `etcetera` crate to use it on macOS. Config locations for other platforms are unchanged.