### PR TITLE
Fix install script

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -132,8 +132,8 @@ sha256() {
 
 latest_version_released() {
    curl -s 'https://api.github.com/repos/denisidoro/navi/releases/latest' \
-      | grep -Eo 'releases/tag/v([0-9\.]+)' \
-      | sed 's|releases/tag/v||'
+      | grep -Eo '"html_url": "https://github.com/denisidoro/navi/releases/tag/v([0-9\.]+)' \
+      | sed 's|"html_url": "https://github.com/denisidoro/navi/releases/tag/v||'
 }
 
 asset_url() {


### PR DESCRIPTION
Fix function that checks for the latest released version so it doesn't match an unexpected line and results in an incorrect URL being generated. Quick-and-dirty approach.

Fixes #834 .

Output of the function code with this change is correct:

<img width="767" alt="image" src="https://user-images.githubusercontent.com/716334/234078011-9d052a20-33c5-4425-8125-bc116b3cc8e2.png">

VS the current output:

<img width="607" alt="image" src="https://user-images.githubusercontent.com/716334/234078190-319739cc-5044-43b5-ae7a-a7aae2644dc0.png">
