### PR TITLE
Update badge link for CI workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# navi <img src="https://raw.githubusercontent.com/denisidoro/navi/master/assets/icon.png" alt="icon" height="28px"/> [![Actions Status](https://github.com/denisidoro/navi/workflows/Tests/badge.svg)](https://github.com/denisidoro/navi/actions) ![GitHub release](https://img.shields.io/github/v/release/denisidoro/navi?include_prereleases)
+# navi <img src="https://raw.githubusercontent.com/denisidoro/navi/master/assets/icon.png" alt="icon" height="28px"/> [![Actions Status](https://github.com/denisidoro/navi/workflows/CI/badge.svg)](https://github.com/denisidoro/navi/actions) ![GitHub release](https://img.shields.io/github/v/release/denisidoro/navi?include_prereleases)
 
 An interactive cheatsheet tool for the command-line.
 


### PR DESCRIPTION
Looks like the workflow has been renamed since 2ca1d8fc85333c1a8414a71e288073c264d74b1f

## Before

<img width="447" alt="before" src="https://github.com/denisidoro/navi/assets/1180335/93b3ee91-55da-4d97-bf21-bbcf4e737fce">

## After

<img width="437" alt="after" src="https://github.com/denisidoro/navi/assets/1180335/8f864373-24b7-4448-be00-6b1f8429637f">