### PR TITLE
fix: #845 Add config option to support tealdeer

### DIFF
--- a/docs/config_file_example.yaml
+++ b/docs/config_file_example.yaml
@@ -25,11 +25,14 @@ finder:
 # path: /path/to/some/dir # (DEPRECATED) equivalent to the --path option
 
 # search:
-# tags: git,!checkout # equivalent to the --tag-rules option
+#   tags: git,!checkout # equivalent to the --tag-rules option
+
+# client:
+#   tealdeer: true # enables tealdeer support for navi --tldr
 
 shell:
   # Shell used for shell out. Possible values: bash, zsh, dash, ...
   # For Windows, use `cmd.exe` instead.
   command: bash
-  
+
   # finder_command: bash # similar, but for fzf's internals

--- a/src/clients/tldr.rs
+++ b/src/clients/tldr.rs
@@ -1,4 +1,5 @@
 use crate::prelude::*;
+use crate::config::CONFIG;
 use std::process::{Command, Stdio};
 
 lazy_static! {
@@ -51,7 +52,9 @@ fn markdown_lines(query: &str, markdown: &str) -> Vec<String> {
 }
 
 pub fn call(query: &str) -> Result<Vec<String>> {
-    let args = [query, "--markdown"];
+    let tealdeer = CONFIG.tealdeer();
+    let output_flag = if tealdeer { "--raw" } else { "--markdown" };
+    let args = [query, output_flag];
 
     let child = Command::new("tldr")
         .args(args)
@@ -86,9 +89,9 @@ Note:
         Ok(lines)
     } else {
         let msg = format!(
-            "Failed to call: 
+            "Failed to call:
 tldr {}
- 
+
 Output:
 {}
 
@@ -96,8 +99,9 @@ Error:
 {}
 
 Note:
+The client.tealdeer config option can be set to enable tealdeer support.
 Please make sure you're using a version that supports the --markdown flag.
-If you are already using a supported version you can ignore this message. 
+If you are already using a supported version you can ignore this message.
 {}
 ",
             args.join(" "),

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -99,6 +99,10 @@ impl Config {
             .or_else(|| self.yaml.finder.overrides_var.clone())
     }
 
+    pub fn tealdeer(&self) -> bool {
+        self.yaml.client.tealdeer.clone()
+    }
+
     pub fn shell(&self) -> String {
         self.yaml.shell.command.clone()
     }

--- a/src/config/yaml.rs
+++ b/src/config/yaml.rs
@@ -78,6 +78,12 @@ pub struct Shell {
     pub finder_command: Option<String>,
 }
 
+#[derive(Deserialize, Debug)]
+#[serde(default)]
+pub struct Client {
+    pub tealdeer: bool,
+}
+
 #[derive(Deserialize, Default, Debug)]
 #[serde(default)]
 pub struct YamlConfig {
@@ -86,6 +92,7 @@ pub struct YamlConfig {
     pub cheats: Cheats,
     pub search: Search,
     pub shell: Shell,
+    pub client: Client,
 }
 
 impl YamlConfig {
@@ -159,6 +166,14 @@ impl Default for Shell {
         Self {
             command: "bash".to_string(),
             finder_command: None,
+        }
+    }
+}
+
+impl Default for Client {
+    fn default() -> Self {
+        Self {
+            tealdeer: false,
         }
     }
 }


### PR DESCRIPTION
I'm not sure if using a config file option was the best way to go about this, or if it would have been better to simply add a --tealdeer command line option instead.

If nothing else, maybe this could be used as a temporary solution to allow users to enable tealdeer support with a config option.