### PR TITLE
Update default install order

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -251,13 +251,13 @@ install_navi() {
 
    elif command_exists brew; then
       brew install navi
-
-   elif command_exists cargo; then
-      cargo install navi
-
+   
    elif [[ -n "$target" ]]; then
       local -r version="$(latest_version_released)"
       download_asset "$version" "$target" || error_installing
+
+   elif command_exists cargo; then
+      cargo install navi
 
    else
       error_installing


### PR DESCRIPTION
The script defaults to using brew, and then cargo, then finally to the latest releases on Github. Since the version on crates.io is not up to date, I suggest change the priority of using cargo to the last.