### PR TITLE
Added error message for incompatible fzf version

### DIFF
--- a/src/finder/mod.rs
+++ b/src/finder/mod.rs
@@ -3,11 +3,17 @@ use crate::prelude::*;
 use std::io::Write;
 use std::process::{self, Output};
 use std::process::{Command, Stdio};
+use std::string::ToString;
+
 pub mod structures;
 use clap::ValueEnum;
 pub use post::process;
 use structures::Opts;
 use structures::SuggestionType;
+
+const MIN_FZF_VERSION_MAJOR: u32 = 0;
+const MIN_FZF_VERSION_MINOR: u32 = 23;
+const MIN_FZF_VERSION_PATCH: u32 = 1;
 
 mod post;
 
@@ -47,6 +53,24 @@ fn parse(out: Output, opts: Opts) -> Result<String> {
 }
 
 impl FinderChoice {
+    fn check_fzf_version() -> Option<(u32, u32, u32)> {
+        let output = Command::new("fzf")
+            .arg("--version")
+            .output()
+            .ok()?
+            .stdout;
+        let version_string = String::from_utf8(output).ok()?;
+        let version_parts: Vec<_> = version_string.split('.').collect();
+        if version_parts.len() == 3 {
+            let major = version_parts[0].parse().ok()?;
+            let minor = version_parts[1].parse().ok()?;
+            let patch = version_parts[2].split_whitespace().next()?.parse().ok()?;
+            Some((major, minor, patch))
+        } else {
+            None
+        }
+    }
+
     pub fn call<F, R>(&self, finder_opts: Opts, stdin_fn: F) -> Result<(String, R)>
     where
         F: Fn(&mut dyn Write) -> Result<R>,
@@ -55,6 +79,20 @@ impl FinderChoice {
             Self::Fzf => "fzf",
             Self::Skim => "sk",
         };
+
+        if let Self::Fzf = self {
+            if let Some((major, minor, patch)) = Self::check_fzf_version() {
+                if major == MIN_FZF_VERSION_MAJOR && minor < MIN_FZF_VERSION_MINOR && patch < MIN_FZF_VERSION_PATCH {
+                    eprintln!("Warning: Fzf version {}.{} does not support the preview window layout used by navi.", major, minor);
+                    eprintln!("Consider updating Fzf to a version >= {}.{}.{} or use a compatible layout.",
+                              MIN_FZF_VERSION_MAJOR,
+                              MIN_FZF_VERSION_MINOR,
+                              MIN_FZF_VERSION_PATCH
+                    );
+                    process::exit(1);
+                }
+            }
+        }
 
         let mut command = Command::new(finder_str);
         let opts = finder_opts.clone();

--- a/src/finder/mod.rs
+++ b/src/finder/mod.rs
@@ -3,7 +3,6 @@ use crate::prelude::*;
 use std::io::Write;
 use std::process::{self, Output};
 use std::process::{Command, Stdio};
-
 pub mod structures;
 use clap::ValueEnum;
 pub use post::process;

--- a/src/finder/mod.rs
+++ b/src/finder/mod.rs
@@ -3,7 +3,6 @@ use crate::prelude::*;
 use std::io::Write;
 use std::process::{self, Output};
 use std::process::{Command, Stdio};
-use std::string::ToString;
 
 pub mod structures;
 use clap::ValueEnum;


### PR DESCRIPTION
Navi currently uses fzf with the parameters `fzf --preview-window up:2:nohidden` while `nohidden` was added to `fzf` in version [0.23.1.](https://github.com/junegunn/fzf/compare/0.23.0...0.23.1)  
Lots of popular distros, like _Ubuntu 20.04_ or _Fedora 30_ still distribute **fzf 0.20.0** which leads to tickets like #447, #577, or #805.

This PR adds a clear message stating whats wrong instead of forwarding the `invalid preview window layout: up:2:nohidden` error message to the end user.