### PR TITLE
fixed cargo clippy warnings

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -100,7 +100,7 @@ impl Config {
     }
 
     pub fn tealdeer(&self) -> bool {
-        self.yaml.client.tealdeer.clone()
+        self.yaml.client.tealdeer
     }
 
     pub fn shell(&self) -> String {

--- a/src/config/yaml.rs
+++ b/src/config/yaml.rs
@@ -80,6 +80,7 @@ pub struct Shell {
 
 #[derive(Deserialize, Debug)]
 #[serde(default)]
+#[derive(Default)]
 pub struct Client {
     pub tealdeer: bool,
 }
@@ -167,11 +168,5 @@ impl Default for Shell {
             command: "bash".to_string(),
             finder_command: None,
         }
-    }
-}
-
-impl Default for Client {
-    fn default() -> Self {
-        Self { tealdeer: false }
     }
 }

--- a/src/finder/mod.rs
+++ b/src/finder/mod.rs
@@ -81,12 +81,10 @@ impl FinderChoice {
                     && patch < MIN_FZF_VERSION_PATCH
                 {
                     eprintln!(
-                        "Warning: Fzf version {}.{} does not support the preview window layout used by navi.",
-                        major, minor
+                        "Warning: Fzf version {major}.{minor} does not support the preview window layout used by navi.",
                     );
                     eprintln!(
-                        "Consider updating Fzf to a version >= {}.{}.{} or use a compatible layout.",
-                        MIN_FZF_VERSION_MAJOR, MIN_FZF_VERSION_MINOR, MIN_FZF_VERSION_PATCH
+                        "Consider updating Fzf to a version >= {MIN_FZF_VERSION_MAJOR}.{MIN_FZF_VERSION_MINOR}.{MIN_FZF_VERSION_PATCH} or use a compatible layout.",
                     );
                     process::exit(1);
                 }


### PR DESCRIPTION
Looks like cargo clippy was still failing. It started failing with #873, but after my PR #888 even more so, so I fixed it here. Now the master branch should be clean and the CI/CD pipelines working.

I'd suggest adding the runners to every PR, so this won't happen again.