### PR TITLE
docs: mention navi syntax highlighting vs-code extension

### DIFF
--- a/docs/cheatsheet_syntax.md
+++ b/docs/cheatsheet_syntax.md
@@ -32,6 +32,9 @@ Lines starting with:
 
 All the other non-empty lines are considered as executable commands.
 
+Tip: if you are editing cheatsheets in Visual Studio Code, you could enable syntax highlighting
+by installing [this extension](https://marketplace.visualstudio.com/items?itemName=yanivmo.navi-cheatsheet-language).
+
 ### Variables
 
 The interface prompts for variable names inside brackets (eg `<branch>`).


### PR DESCRIPTION
I published a simple Visual Studio extension for navi syntax highlighting and added a short mention in the syntax doc.

The extension page in the Visual Studio Marketplace: https://marketplace.visualstudio.com/items?itemName=yanivmo.navi-cheatsheet-language
The extension repository in GitHub: https://github.com/yanivmo/navi-cheatsheet-language