### PR TITLE
Fixed URL for cheat path

### DIFF
--- a/docs/navi_config.md
+++ b/docs/navi_config.md
@@ -33,7 +33,7 @@ The default `.cheat` files paths are defined in the `$NAVI_PATH` environment var
 ```sh
 export NAVI_PATH='/path/to/a/dir:/path/to/another/dir:/yet/another/dir'
 ```
-If this environment variable is unset or if all directories do not exist, `navi` uses the [paths defined in the config file](https://github.com/tapyu/to-rm-navi/blob/master/docs/config_file_example.yaml#L21-L24). Finally, if there is no config file or if the `.cheat` file paths was not set, the default `.cheat` file paths fallbacks to `~/.local/share/navi/cheats/`. The command
+If this environment variable is unset or if all directories do not exist, `navi` uses the [paths defined in the config file](https://github.com/denisidoro/navi/blob/master/docs/config_file_example.yaml#L21-L24). Finally, if there is no config file or if the `.cheat` file paths was not set, the default `.cheat` file paths fallbacks to `~/.local/share/navi/cheats/`. The command
 ```sh
 navi info cheats-path
 ```


### PR DESCRIPTION
Might be there more of it, because the old name was (to-rm-navi) so i assume that meant to "to remove"