### PR TITLE
Updated rustc channel

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.67.0"
+channel = "1.74.0"
 components = [ "rustfmt", "clippy" ]


### PR DESCRIPTION
Updated Rust toolchain version from `1.67.0` to `1.74.0`.

I tried on both linux (Fedora 41) and windows 11 to build the project without any channel override and there weren't any issue.

Closes #911 