### PR TITLE
Add bind name in tmux.md

### DIFF
--- a/docs/tmux.md
+++ b/docs/tmux.md
@@ -5,7 +5,7 @@ You can use **navi** as a [Tmux](https://github.com/tmux/tmux/wiki) widget to re
 Add these lines to your Tmux config file to access **navi** by pressing `prefix + C-g`.
 
 ```sh
-bind-key -T prefix C-g split-window \
+bind-key -N "Open Navi (cheat sheets)" -T prefix C-g split-window \
   "$SHELL --login -i -c 'navi --print | head -n 1 | tmux load-buffer -b tmp - ; tmux paste-buffer -p -t {last} -b tmp -d'"
 ```
 


### PR DESCRIPTION
Just added a name to the tmux bind-key, which makes it appear in `Prefix + ?` (list of all named keybinds)
![image](https://github.com/user-attachments/assets/9de5fce0-faec-43f9-8348-5458df5299db)

