### PR TITLE
shell: quote fish_key_bindings in fish plugin

### DIFF
--- a/shell/navi.plugin.fish
+++ b/shell/navi.plugin.fish
@@ -22,7 +22,7 @@ function _navi_smart_replace
     commandline -f repaint
 end
 
-if test $fish_key_bindings = fish_default_key_bindings
+if test "$fish_key_bindings" = fish_default_key_bindings
     bind \cg _navi_smart_replace
 else
     bind -M insert \cg _navi_smart_replace


### PR DESCRIPTION
This was an oversight in #671, which could lead to a one-time error if fish has not initialized its settings (either because it is the first-run or the settings file `fish_variables` was deleted):

```
test: Missing argument at index 3
= fish_default_key_bindings
                            ^
- (line 25): 
if test $fish_key_bindings = fish_default_key_bindings
   ^
from sourcing file -
        called on line 26 of file ~/.config/fish/config.fish
from sourcing file ~/.config/fish/config.fish
        called during startup
```