### PR TITLE
Allow delimiter variable option to be set from config.yaml

### DIFF
--- a/docs/config_file_example.yaml
+++ b/docs/config_file_example.yaml
@@ -17,6 +17,7 @@ finder:
   command: fzf # equivalent to the --finder option
   # overrides: --tac # equivalent to the --fzf-overrides option
   # overrides_var: --tac # equivalent to the --fzf-overrides-var option
+  # delimiter_var: \s\s+ # equivalent to the --delimiter option that is used with --column option when you extract a column from the selected result for a variable
 
 # cheats:
 #   paths:

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -99,6 +99,10 @@ impl Config {
             .or_else(|| self.yaml.finder.overrides_var.clone())
     }
 
+    pub fn delimiter_var(&self) -> Option<String> {
+        self.yaml.finder.delimiter_var.clone()
+    }
+
     pub fn tealdeer(&self) -> bool {
         self.yaml.client.tealdeer
     }

--- a/src/config/yaml.rs
+++ b/src/config/yaml.rs
@@ -47,6 +47,7 @@ pub struct Finder {
     pub command: FinderChoice,
     pub overrides: Option<String>,
     pub overrides_var: Option<String>,
+    pub delimiter_var: Option<String>,
 }
 
 fn finder_deserialize<'de, D>(deserializer: D) -> Result<FinderChoice, D::Error>
@@ -158,6 +159,7 @@ impl Default for Finder {
             command: FinderChoice::Fzf,
             overrides: None,
             overrides_var: None,
+            delimiter_var: None,
         }
     }
 }

--- a/src/finder/structures.rs
+++ b/src/finder/structures.rs
@@ -66,6 +66,7 @@ impl Opts {
             overrides: CONFIG.fzf_overrides_var(),
             suggestion_type: SuggestionType::SingleRecommendation,
             prevent_select1: false,
+            delimiter: CONFIG.delimiter_var(),
             ..Default::default()
         }
     }


### PR DESCRIPTION
Close #940 

After this change, if `delimiter_var` is specified in config.yaml, `parser::tests::test_parse_variable_line` test will fail.
https://github.com/denisidoro/navi/blob/5515367dc8a2a561d2d82b8352f729b1da4120d3/src/parser.rs#L349