### PR TITLE
Fix CI lint errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,10 @@
 # for simplicity we are compiling and testing everything on the Ubuntu environment only.
 # For multi-OS testing see the `cross.yml` workflow.
 
-on: [push]
+on:
+  push:
+  pull_request:
+    branches: [master]
 
 name: CI
 

--- a/src/common/shell.rs
+++ b/src/common/shell.rs
@@ -12,6 +12,7 @@ pub enum Shell {
     Fish,
     Elvish,
     Nushell,
+    #[allow(clippy::enum_variant_names)]
     PowerShell,
 }
 

--- a/src/common/terminal.rs
+++ b/src/common/terminal.rs
@@ -50,7 +50,7 @@ pub fn parse_ansi(ansi: &str) -> Option<style::Color> {
 }
 
 #[derive(Debug, Clone)]
-pub struct Color(pub style::Color);
+pub struct Color(#[allow(unused)] pub style::Color); // suppress warning: field `0` is never read.
 
 impl FromStr for Color {
     type Err = &'static str;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -254,9 +254,8 @@ impl<'a> Parser<'a> {
             }
 
             // duplicate
-            if !item.tags.is_empty() {
-                item.comment.is_empty();
-            }
+            // if !item.tags.is_empty() && !item.comment.is_empty() {}
+
             // blank
             if line.is_empty() {
                 if !item.snippet.is_empty() {


### PR DESCRIPTION
Fix lint errors by `cargo clippy -- -D warnings`, and change ci.yml so that ci also runs on pull requests.
This prevent ci from failing on the master branch.