### PR TITLE
Allow cheatsheet items with same descriptions

### DIFF
--- a/src/structures/item.rs
+++ b/src/structures/item.rs
@@ -18,6 +18,6 @@ impl Item {
     }
 
     pub fn hash(&self) -> u64 {
-        fnv(&format!("{}{}", &self.tags.trim(), &self.comment.trim()))
+        fnv(&format!("{}{}{}", &self.tags.trim(), &self.comment.trim(), &self.snippet.trim()))
     }
 }


### PR DESCRIPTION
Prior to the refactor performed in https://github.com/denisidoro/navi/pull/760, cheatsheet items could have the same tags and the same description, but a different snippet, and they would all be listed in the finder.

After the refactor, this behavior has changed and such items will now be treated as non-unique.

There appears to be no reason to require item descriptions to be distinct, so this patch restores the earlier behavior.

Fixes: #951 