### PR TITLE
Introduce the new default commands + Add a reference for the configuration + Add some debug information along

### DIFF
--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -1,6 +1,6 @@
 use clap::Args;
 use clap::ValueEnum;
-
+use crossterm::style::Stylize;
 use crate::filesystem;
 use crate::prelude::*;
 
@@ -13,9 +13,13 @@ pub struct Input {
 #[derive(Debug, Clone, ValueEnum)]
 pub enum Info {
     CheatsExample,
+    ConfigExample,
+
     CheatsPath,
     ConfigPath,
-    ConfigExample,
+
+    DefaultCheatsPath,
+    DefaultConfigPath
 }
 
 impl Runnable for Input {
@@ -23,10 +27,19 @@ impl Runnable for Input {
         let info = &self.info;
 
         match info {
+            // Here should be the example commands
             Info::CheatsExample => println!("{}", include_str!("../../docs/cheat_example.cheat")),
-            Info::CheatsPath => println!("{}", &filesystem::default_cheat_pathbuf()?.to_string()),
-            Info::ConfigPath => println!("{}", &filesystem::default_config_pathbuf()?.to_string()),
             Info::ConfigExample => println!("{}", include_str!("../../docs/config_file_example.yaml")),
+
+            // Here should be the old deprecated default value commands
+            Info::CheatsPath => println!("{} Please use `info default-cheats-path` instead.\n\n\
+                {}","DEPRECATED:".red(), &filesystem::default_cheat_pathbuf()?.to_string()),
+            Info::ConfigPath => println!("{} Please use `info default-config-path` instead.\n\n\
+                {}", "DEPRECATED:".red(), &filesystem::default_config_pathbuf()?.to_string()),
+
+            // Here should be the default values (computed at compile time)
+            Info::DefaultCheatsPath => println!("{}", &filesystem::default_cheat_pathbuf()?.to_string()),
+            Info::DefaultConfigPath => println!("{}", &filesystem::default_config_pathbuf()?.to_string()),
         }
         Ok(())
     }

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -53,23 +53,12 @@ fn compiled_default_path(path: Option<&str>) -> Option<PathBuf> {
 }
 
 pub fn default_cheat_pathbuf() -> Result<PathBuf> {
-    if cfg!(target_os = "macos") {
-        let base_dirs = etcetera::base_strategy::Apple::new()?;
+    let mut pathbuf = get_data_dir_by_platform()?;
 
-        let mut pathbuf = base_dirs.data_dir();
-        pathbuf.push("navi");
-        pathbuf.push("cheats");
-        if pathbuf.exists() {
-            return Ok(pathbuf);
-        }
-    }
-
-    let base_dirs = etcetera::choose_base_strategy()?;
-
-    let mut pathbuf = base_dirs.data_dir();
     pathbuf.push("navi");
     pathbuf.push("cheats");
-    if !pathbuf.exists() {
+
+    if pathbuf.exists() {
         if let Some(path) = compiled_default_path(option_env!("NAVI_PATH")) {
             pathbuf = path;
         }
@@ -78,22 +67,11 @@ pub fn default_cheat_pathbuf() -> Result<PathBuf> {
 }
 
 pub fn default_config_pathbuf() -> Result<PathBuf> {
-    if cfg!(target_os = "macos") {
-        let base_dirs = etcetera::base_strategy::Apple::new()?;
+    let mut pathbuf = get_config_dir_by_platform()?;
 
-        let mut pathbuf = base_dirs.config_dir();
-        pathbuf.push("navi");
-        pathbuf.push("config.yaml");
-        if pathbuf.exists() {
-            return Ok(pathbuf);
-        }
-    }
-
-    let base_dirs = etcetera::choose_base_strategy()?;
-
-    let mut pathbuf = base_dirs.config_dir();
     pathbuf.push("navi");
     pathbuf.push("config.yaml");
+
     if !pathbuf.exists() {
         if let Some(path) = compiled_default_path(option_env!("NAVI_CONFIG")) {
             pathbuf = path;
@@ -108,6 +86,49 @@ pub fn cheat_paths(path: Option<String>) -> Result<String> {
     } else {
         Ok(default_cheat_pathbuf()?.to_string())
     }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+// Here are other functions, unrelated to CLI commands (or at least not directly related)
+//
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+/// Returns the data dir computed for each platform.
+///
+/// We are currently handling two cases: When the platform is `macOS` and when the platform isn't (including `Windows` and `Linux/Unix` platforms)
+fn get_data_dir_by_platform() -> Result<PathBuf> {
+    let pathbuf;
+
+    if cfg!(target_os = "macos") {
+        let base_dirs = etcetera::base_strategy::Apple::new()?;
+
+        pathbuf = base_dirs.data_dir();
+    } else {
+        let base_dirs = etcetera::choose_base_strategy()?;
+        pathbuf = base_dirs.data_dir()
+    }
+
+    Ok(pathbuf)
+}
+
+/// Returns the config dir computed for each platform.
+///
+/// We are currently handling two cases: When the platform is `macOS` and when the platform isn't (including `Windows` and `Linux/Unix` platforms)
+fn get_config_dir_by_platform() -> Result<PathBuf> {
+    let pathbuf;
+
+    if cfg!(target_os = "macos") {
+        let base_dirs = etcetera::base_strategy::Apple::new()?;
+
+        pathbuf = base_dirs.config_dir();
+    } else {
+        let base_dirs = etcetera::choose_base_strategy()?;
+
+        pathbuf = base_dirs.config_dir();
+    }
+
+    Ok(pathbuf)
 }
 
 pub fn tmp_pathbuf() -> Result<PathBuf> {


### PR DESCRIPTION
This PR is the result of the discussions in #938.

It adds the following:

- Two new info commands ( `default-cheats-path` and `default-config-path` ) supposed to take over from the old info commands ( `cheats-path` and `config-path` )
- Introduces a deprecation notice on the old info commands
- Adds a reference inside the configuration on where it has been loaded from
- Adds some minor debug expressions
- Standardizes the way the functions retrieve without introducing a breaking change (normally)