### PR TITLE
Improved vim syntax highlighting documentation

### DIFF
--- a/docs/vim.md
+++ b/docs/vim.md
@@ -8,6 +8,6 @@ The rules are defined based on the [Cheatsheet syntax](cheatsheet_syntax.md).
 syntax match Comment "\v^;.*$"
 syntax match Statement "\v^\%.*$"
 syntax match Operator "\v^\#.*$"
-syntax match String "\v\<.*\>"
+syntax match String "\v\<.{-}\>"
 syntax match String "\v^\$.*$"
 ```


### PR DESCRIPTION
Improved documentation of syntax highlighting, catching the closest closing bracket

**Before:**
![image](https://github.com/user-attachments/assets/a0aecf0e-dbe6-480b-be37-d2f48ce9c7c3)

**After:**
![image](https://github.com/user-attachments/assets/c540e53c-4011-425e-a5e8-ba9ad398c03b)
