### PR TITLE
Fix widget powershell

### DIFF
--- a/shell/navi.plugin.ps1
+++ b/shell/navi.plugin.ps1
@@ -42,6 +42,7 @@ $null = New-Module {
             }
         }
 
+        [Microsoft.PowerShell.PSConsoleReadLine]::RevertLine()
         [Microsoft.PowerShell.PSConsoleReadLine]::InvokePrompt()
 
         ### Handling the case when the user escapes without selecting any entry

--- a/src/structures/item.rs
+++ b/src/structures/item.rs
@@ -18,6 +18,11 @@ impl Item {
     }
 
     pub fn hash(&self) -> u64 {
-        fnv(&format!("{}{}{}", &self.tags.trim(), &self.comment.trim(), &self.snippet.trim()))
+        fnv(&format!(
+            "{}{}{}",
+            &self.tags.trim(),
+            &self.comment.trim(),
+            &self.snippet.trim()
+        ))
     }
 }


### PR DESCRIPTION
Clear current input before inserting navi's output.
If navi is invoked while input is present, the input must be cleared before output.
The line `[Microsoft.PowerShell.PSConsoleReadLine]::RevertLine()` was present when the [pr](https://github.com/denisidoro/navi/pull/947) was submitted, but seems to have been removed while fixing it.