### PR TITLE
fix: prevent prompt corruption in fish v4

### DIFF
--- a/shell/navi.plugin.fish
+++ b/shell/navi.plugin.fish
@@ -5,6 +5,7 @@ function _navi_smart_replace
         set --local best_match (navi --print --query "$query" --best-match)
         if test -n "$best_match"
             commandline --current-process $best_match
+            commandline -f repaint
             return
         end
     end
@@ -12,6 +13,7 @@ function _navi_smart_replace
     set --local candidate (navi --print --query "$query")
     if test -n "$candidate"
         commandline --current-process $candidate
+        commandline -f repaint
     end
 end
 


### PR DESCRIPTION
fish v4 introduced new multiline prompt rendering behavior that breaks when interactive commands like `navi` are injected via keybindings. this resulted in partial prefix symbols (e.g. from a prompt's newline component) being left on screen and improperly rendering the expanded command (e.g. `gzgzip` instead of `gzip`).

this forces a full redraw so it's cosmetically identical to running `navi` (as a command without insertion)

## Steps to repro

### Prerequisites 
 - fish v4.0.2 with tide prompt 6.1.1
 - navi 2.24.0
 - Example: `gzip.cheat`
```
% gzip

# compress and retain
gzip --keep --best <file>
```

 1. Trigger using `\cg` keybind (via `navi widget fish | source`)
 2. Select `gzip` cheat (e.g. `gzip foo`)
 3. Press enter

**Expected**: `gzip --keep --best foo` 
**Actual**: `gzgzip --keep --best foo` (command is correct, painting is not)
![image](https://github.com/user-attachments/assets/7519f4ce-0f6d-4b81-9cc7-18b125d5f562)

