### PR TITLE
feat: Add `--locked` to `cargo install` in release script

### DIFF
--- a/scripts/release
+++ b/scripts/release
@@ -87,7 +87,7 @@ release() {
   ### Since the default behaviour of cross is to compile from
   ### a rustup target if it doesn't find one for itself.
   rustup target add $env_target
-  cargo install cross
+  cargo install cross --locked
 
   ### We're building the release via cross for the target environment
   cross build --release --target "$env_target"


### PR DESCRIPTION
## what

Add `--locked` to `cargo install` in release script

## why

https://doc.rust-lang.org/cargo/commands/cargo-install.html#dealing-with-the-lockfile

Without this option, fresh builds from `master` fail for me