### PR TITLE
docs: Fix typo in configuration example

### DIFF
--- a/docs/configuration/README.md
+++ b/docs/configuration/README.md
@@ -113,7 +113,7 @@ style:
   comment:
     color: <your color for comments>
   snippet:
-    color: <you color for snippets>
+    color: <your color for snippets>
 ```
 
 Below is an example of what to do if you'd like navi to look like the French flag:


### PR DESCRIPTION
This PR corrects a minor typo in the docs/configuration/README.md file.

In the "Navi colors" section, the example code for config.yaml contained the line color: "you color for snippets". This has been corrected to color: "your color for snippets".