### PR TITLE
Removed head -n 1 from tmux widget

### DIFF
--- a/docs/widgets/howto/TMUX.md
+++ b/docs/widgets/howto/TMUX.md
@@ -16,7 +16,7 @@ to your Tmux configuration file.
 
 ```sh
 bind-key -N "Open Navi (cheat sheets)" -T prefix C-g split-window \
-  "$SHELL --login -i -c 'navi --print | head -n 1 | tmux load-buffer -b tmp - ; tmux paste-buffer -p -t {last} -b tmp -d'"
+  "$SHELL --login -i -c 'navi --print | tmux load-buffer -b tmp - ; tmux paste-buffer -p -t {last} -b tmp -d'"
 ```
 
 ## Example cheatsheet


### PR DESCRIPTION
The TMUX widget has `head -n 1` inside of it, meaning if you have a multiline navi command it only inserts the first line. The expected behaviour is for it to insert all the lines as it does with the normal navi CLI tool. I'm not sure why this was even here in the first place.