### PR TITLE
fix: bash widget sanitization for &

### DIFF
--- a/shell/navi.plugin.bash
+++ b/shell/navi.plugin.bash
@@ -16,8 +16,11 @@ _navi_widget() {
       local -r replacement="$(_navi_call --print --query "$last_command")"
       local output="$input"
       if [ -n "$replacement" ]; then
-         output="${input}_NAVIEND"
-         output="${output//$find/$replacement}"
+        output="${input}_NAVIEND"
+        output=$(
+          shopt -u patsub_replacement
+          printf '%s' "${output//"$find"/"$replacement"}"
+        )
       fi
    fi
 


### PR DESCRIPTION
In the bash widget readline code make sure that bash's `patsub_replacement` is temporarily unset to avoid having `${input}_NAVIEND` in the final command when the expanded $replacement contains `&`