### PR TITLE
Fix fish widget multi-line snippet and prompt rendering

### DIFF
--- a/shell/navi.plugin.fish
+++ b/shell/navi.plugin.fish
@@ -28,20 +28,20 @@ function _navi_smart_replace
             # boundaries and flattens multi-line snippets into a single line
             commandline --replace -- "$best_match"
             commandline --function end-of-line
-            if test "$force_repaint" = true
-                commandline --function repaint
-            end
-            return
         end
     end
 
-    set --local candidate (navi --print --query "$query")
-    if test -n "$candidate"
-        commandline --replace -- "$candidate"
-        commandline --function end-of-line
-        if test "$force_repaint" = true
-            commandline --function repaint
+    if test -z "$best_match"
+        set --local candidate (navi --print --query "$query")
+        if test -n "$candidate"
+            commandline --replace -- "$candidate"
+            commandline --function end-of-line
         end
+    end
+
+    # always repaint to restore the prompt after fzf clobbers the terminal
+    if test "$force_repaint" = true
+        commandline --function repaint
     end
 end
 


### PR DESCRIPTION
Fixes two issues with the fish shell widget when using multi-line snippets and multi-line prompts (e.g. tide, starship). This updates my fix in #982.

## Problems

### 1. Multi-line snippets are flattened to a single line

Snippets with backslash continuations:

```sh
ffmpeg
  -i
  -preset slow
  -codec:a aac
```

are inserted as:

```sh
ffmpeg \ -i  \ -preset slow \ -codec:a aac
```

This is caused by `commandline --current-process` treats newlines as process (pipe) boundaries, collapsing multi-line output into a single line.

### 2. Multi-line prompts lose their border after exiting `navi` 

With a multi-line prompt like tide:

```sh
╭─ user@host ~/project
╰─ gzip --keep --best
```

After triggering `navi widget fish | source` for the binding Ctrl+G and cancelling or selecting, the prompt renders as:

```sh
gzip --keep --best
```

It should be
```sh
╰─ gzip --keep --best
```

The `╭─`/`╰─` borders disappear because `fzf` clobbers the terminal and `repaint` only ran inside the success branches — cancelling out of `navi` skipped it entirely.

## Changes
- Replace `commandline --current-process $var` with `commandline --replace -- "$var"`
  - `--replace` operates on the full buffer and preserves newlines
  - `--` prevents snippets starting with `-` from being interpreted as flags
  - Quoting `"$var"` prevents word splitting
- Add `commandline --function end-of-line` to position cursor after replacement
- Move `repaint` from inside the `best_match`/`candidate` branches to the end of the function
- Repaint now runs unconditionally — whether a snippet was selected, the user cancelled, or no matches were found
- Remove early `return` from `best_match` branch; gate `candidate` fallback with `test -z "$best_match"` instead