### PR TITLE
Enable specifying pwsh as a command

### DIFF
--- a/src/commands/core/actor.rs
+++ b/src/commands/core/actor.rs
@@ -63,7 +63,7 @@ fn prompt_finder(
 
     let exe = fs::exe_string();
 
-    let preview = if CONFIG.shell().contains("powershell") {
+    let preview = if CONFIG.shell().contains("powershell") || CONFIG.shell().contains("pwsh") {
         format!(
             r#"{exe} preview-var {{+}} "{{q}}" "{name}"; {extra}"#,
             exe = exe,


### PR DESCRIPTION
Enable the specification of `pwsh` in the `shell.command` section of `config.yaml`