### PR TITLE
Make bash available on Windows

### DIFF
--- a/docs/configuration/README.md
+++ b/docs/configuration/README.md
@@ -231,3 +231,45 @@ finder:
 You can override this configuration with the `--delimiter` instruction in the variable definition of your cheat.\
 See [/docs/cheatsheet/syntax/](/docs/cheatsheet/syntax/README.md#advanced-variable-options) for more details.
 
+## Changing shell
+
+You can change the shell that is used inside navi.
+
+```yaml
+shell:
+  command: bash
+  finder_command: bash
+```
+
+`shell.command` is used to execute commands that generate possible values for variables.
+`shell.finder_command` is used inside fzf.
+
+For example, suppose you have the following cheat sheet.
+
+```
+# ISO 8061
+date -I<iso_unit>
+
+$ iso_unit: echo -e 'date\nhours\nminutes\nseconds\nns'
+```
+
+The command `echo -e 'date\nhours\nminutes\nseconds\nns'` is executed in the shell specified by `shell.command`.
+
+### Use bash on Windows
+
+On Windows, there are several bash environments available, including MSYS2's bash, Git Bash, and [w64devkit](https://github.com/skeeto/w64devkit)'s bash.
+The w64devkit's bash isn't actually bash, but it can be used just like bash.
+Here is an example of using Git Bash.
+
+```yaml
+shell:
+  command: "\"C:/Program Files/Git/bin/bash.exe\""
+  finder_command: "C:/Program Files/Git/bin/bash.exe"
+  forward_slash_path: true
+```
+
+If the path to the executable contains spaces, it must be quoted in the `shell.command`.
+Unlike `shell.command`, `shell.finder_command` does not require the path to be quoted even if it contains spaces.
+Additionaly, `shell.forward_slash_path` must be set to `true`.
+`shell.forward_slash_path: true` can be used with bash environments that interpret paths with forward slashes (e.g., `C:/path/to/bash.exe`).
+Other than Windows, setting `shell.forward_slash_path` has no effect.

--- a/src/common/fs.rs
+++ b/src/common/fs.rs
@@ -90,6 +90,20 @@ fn exe_abs_string() -> Result<String> {
     pathbuf_to_string(&exe_pathbuf()?)
 }
 
+#[cfg(target_family = "windows")]
+pub fn exe_string() -> String {
+    exe_abs_string()
+        .map(|exe| {
+            if CONFIG.forward_slash_path() {
+                exe.replace("\\", "/")
+            } else {
+                exe
+            }
+        })
+        .unwrap_or_else(|_| "navi".to_string())
+}
+
+#[cfg(not(target_family = "windows"))]
 pub fn exe_string() -> String {
     exe_abs_string().unwrap_or_else(|_| "navi".to_string())
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -146,6 +146,10 @@ impl Config {
             .unwrap_or_else(|| self.yaml.shell.command.clone())
     }
 
+    pub fn forward_slash_path(&self) -> bool {
+        self.yaml.shell.forward_slash_path
+    }
+
     pub fn tag_rules(&self) -> Option<String> {
         self.clap
             .tag_rules

--- a/src/config/yaml.rs
+++ b/src/config/yaml.rs
@@ -77,6 +77,7 @@ pub struct Search {
 pub struct Shell {
     pub command: String,
     pub finder_command: Option<String>,
+    pub forward_slash_path: bool,
 }
 
 #[derive(Deserialize, Debug)]
@@ -187,6 +188,7 @@ impl Default for Shell {
         Self {
             command: "bash".to_string(),
             finder_command: None,
+            forward_slash_path: false,
         }
     }
 }


### PR DESCRIPTION
There are several bash environments available on Windows, including MSYS2's bash, Git Bash, and w64devkit's bash.
This change makes these bash available in navi.

Config.yaml settings for using Git Bash.
```yaml
shell:
  command: "\"C:/Program Files/Git/bin/bash.exe\""
  finder_command: "C:/Program Files/Git/bin/bash.exe"
  forward_slash_path: true
```

Before:
<img width="1906" height="464" alt="スクリーンショット 2026-03-22 132639" src="https://github.com/user-attachments/assets/17c14041-18ca-4acd-abf0-e2ad0a098ea1" />

After:
<img width="1905" height="464" alt="スクリーンショット 2026-03-22 132724" src="https://github.com/user-attachments/assets/00f0c385-6bd7-49ee-90a6-c3a4744af4f4" />
