### PR TITLE
ci: add riscv64 to release targets

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -27,6 +27,8 @@ jobs:
           - os: ubuntu-latest
             target: aarch64-linux-android
           - os: ubuntu-latest
+            target: riscv64gc-unknown-linux-gnu
+          - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
           - os: macos-latest
             target: aarch64-apple-darwin


### PR DESCRIPTION
Adds riscv64gc-unknown-linux-gnu to the cross-compile target list. cross-rs has riscv64 Dockerfiles.

For personal accounts: install https://github.com/apps/rise-risc-v-runners-personal on this repo if you want native builds instead of cross-compilation.

Build validated: https://github.com/gounthar/navi/actions/runs/23497643523

Closes #1018