### PR TITLE
Add --key flag to navi widget for custom keybindings

### DIFF
--- a/docs/widgets/README.md
+++ b/docs/widgets/README.md
@@ -63,7 +63,20 @@ Due to Nushell's [unique design](https://www.nushell.sh/book/thinking_in_nu.html
 
 By default, `Ctrl+G` is assigned to launching **navi** (in xonsh can be customized with `$X_NAVI_KEY`, see [xontrib-navi](https://github.com/eugenesvk/xontrib-navi) for details).
 
-There's currently no way to customize the widget behavior out-of-the-box. If you want to change the keybinding or the **navi** flags used by the widget, please:
+To customize the keybinding, use the `--key` flag with your shell's native keybinding syntax:
+
+```sh
+# zsh — bind to Ctrl+Space
+eval "$(navi widget zsh --key '^ ')"
+
+# bash — bind to Ctrl+Space
+eval "$(navi widget bash --key '\C- ')"
+
+# fish — bind to Ctrl+Space
+navi widget fish --key '\c ' | source
+```
+
+If you want to further customize the widget behavior (e.g., change the **navi** flags), you can:
 
 1. run, e.g., `navi widget bash` in your terminal
 2. copy the output

--- a/shell/navi.plugin.bash
+++ b/shell/navi.plugin.bash
@@ -33,7 +33,7 @@ _navi_widget_legacy() {
 }
 
 if [ ${BASH_VERSION:0:1} -lt 4 ]; then
-   bind '"\C-g": " \C-b\C-k \C-u`_navi_widget_legacy`\e\C-e\C-a\C-y\C-h\C-e\e \C-y\ey\C-x\C-x\C-f"'
+   bind '"__NAVI_KEY__": " \C-b\C-k \C-u`_navi_widget_legacy`\e\C-e\C-a\C-y\C-h\C-e\e \C-y\ey\C-x\C-x\C-f"'
 else
-   bind -x '"\C-g": _navi_widget'
+   bind -x '"__NAVI_KEY__": _navi_widget'
 fi

--- a/shell/navi.plugin.elv
+++ b/shell/navi.plugin.elv
@@ -26,4 +26,4 @@ fn call-navi {
   }
 }
 
-set edit:insert:binding[Alt-h] = { call-navi >/dev/tty 2>&1 }
+set edit:insert:binding[__NAVI_KEY__] = { call-navi >/dev/tty 2>&1 }

--- a/shell/navi.plugin.fish
+++ b/shell/navi.plugin.fish
@@ -45,5 +45,5 @@ function _navi_smart_replace
     end
 end
 
-bind \cg _navi_smart_replace
-bind --mode insert \cg _navi_smart_replace
+bind __NAVI_KEY__ _navi_smart_replace
+bind --mode insert __NAVI_KEY__ _navi_smart_replace

--- a/shell/navi.plugin.nu
+++ b/shell/navi.plugin.nu
@@ -22,8 +22,8 @@ export def navi_widget [] {
 
 let nav_keybinding = {
     name: "navi",
-    modifier: control,
-    keycode: char_g,
+    modifier: __NAVI_KEY_MODIFIER__,
+    keycode: __NAVI_KEY_CODE__,
     mode: [emacs, vi_normal, vi_insert],
     event: {
         send: executehostcommand,

--- a/shell/navi.plugin.ps1
+++ b/shell/navi.plugin.ps1
@@ -51,6 +51,6 @@ $null = New-Module {
         }
     }
 
-    Set-PSReadlineKeyHandler -BriefDescription "A keybinding to open Navi Widget" -Chord Ctrl+g -ScriptBlock { Invoke-NaviWidget }
+    Set-PSReadlineKeyHandler -BriefDescription "A keybinding to open Navi Widget" -Chord __NAVI_KEY__ -ScriptBlock { Invoke-NaviWidget }
     Export-ModuleMember -Function @()
 }

--- a/shell/navi.plugin.zsh
+++ b/shell/navi.plugin.zsh
@@ -33,4 +33,4 @@ _navi_widget() {
 }
 
 zle -N _navi_widget
-bindkey '^g' _navi_widget
+bindkey '__NAVI_KEY__' _navi_widget

--- a/src/commands/shell.rs
+++ b/src/commands/shell.rs
@@ -25,6 +25,11 @@ impl Display for Shell {
 pub struct Input {
     #[clap(ignore_case = true, default_value_t = Shell::Bash)]
     pub shell: Shell,
+    /// Custom keybinding for the widget, in shell-native syntax.
+    /// Defaults: bash='\C-g', zsh='^g', fish='\cg', elvish='Alt-h', powershell='Ctrl+g'.
+    /// For nushell, use 'modifier:keycode' format (e.g., 'control:char_g').
+    #[clap(long)]
+    pub key: Option<String>,
 }
 
 impl Runnable for Input {
@@ -38,6 +43,29 @@ impl Runnable for Input {
             Shell::Elvish => include_str!("../../shell/navi.plugin.elv"),
             Shell::Nushell => include_str!("../../shell/navi.plugin.nu"),
             Shell::Powershell => include_str!("../../shell/navi.plugin.ps1"),
+        };
+
+        let content = match shell {
+            Shell::Bash => content.replace("__NAVI_KEY__", self.key.as_deref().unwrap_or("\\C-g")),
+            Shell::Zsh => content.replace("__NAVI_KEY__", self.key.as_deref().unwrap_or("^g")),
+            Shell::Fish => content.replace("__NAVI_KEY__", self.key.as_deref().unwrap_or("\\cg")),
+            Shell::Elvish => content.replace("__NAVI_KEY__", self.key.as_deref().unwrap_or("Alt-h")),
+            Shell::Nushell => {
+                let (modifier, keycode) = if let Some(ref key) = self.key {
+                    let parts: Vec<&str> = key.splitn(2, ':').collect();
+                    if parts.len() == 2 {
+                        (parts[0].trim(), parts[1].trim())
+                    } else {
+                        ("control", parts[0].trim())
+                    }
+                } else {
+                    ("control", "char_g")
+                };
+                content
+                    .replace("__NAVI_KEY_MODIFIER__", modifier)
+                    .replace("__NAVI_KEY_CODE__", keycode)
+            }
+            Shell::Powershell => content.replace("__NAVI_KEY__", self.key.as_deref().unwrap_or("Ctrl+g")),
         };
 
         println!("{content}");


### PR DESCRIPTION
## Summary

- Adds a `--key` flag to `navi widget` so users can customize the keybinding without manually editing widget output
- Shell plugin scripts now use template placeholders (`__NAVI_KEY__`) that are populated at runtime with the default or user-provided value
- Updates widget documentation with examples

### Usage

```sh
# zsh — bind to Ctrl+Space instead of Ctrl+G
eval "$(navi widget zsh --key '^ ')"

# bash
eval "$(navi widget bash --key '\C- ')"

# fish
navi widget fish --key '\c ' | source
```

Without `--key`, behavior is unchanged (defaults to `Ctrl+G` for most shells, `Alt+H` for elvish).

## Context

Related to #837 — while that issue is about zellij support, it touches on the broader need to customize how navi integrates with different terminal environments. `Ctrl+G` is the default unlock for zellij.

The widget docs previously stated: *"There's currently no way to customize the widget behavior out-of-the-box"* — this text was added by the project creator in PR #480 (commit a8ddc13, April 2021). The PR body and comments are empty, and I couldn't find any related issues or discussion suggesting this was a deliberate design constraint rather than simply the state of things at the time.

## Alternative approach

The same effect can be achieved today by rebinding after eval. For example in zsh:

```zsh
eval "$(navi widget zsh)"
bindkey '^ ' _navi_widget
bindkey -r '^g'
```

This works because the widget's `eval` registers the `_navi_widget` function and zle widget — the subsequent `bindkey` calls just reassign the trigger key. The `--key` flag makes this a one-liner instead.

So as an alternative to this PR we can also update the docs.

## Test plan

- [ ] `navi widget zsh` outputs `bindkey '^g'` (default preserved)
- [ ] `navi widget zsh --key '^ '` outputs `bindkey '^ '`
- [ ] `navi widget bash --key '\C- '` replaces both legacy and modern bind lines
- [ ] `navi widget fish --key '\c '` replaces both normal and insert-mode binds
- [ ] `navi widget nushell --key 'control:char_space'` replaces modifier and keycode
- [ ] `navi widget powershell --key 'Ctrl+Space'` replaces Chord value
- [ ] `navi widget elvish --key 'Ctrl-g'` replaces binding key
- [ ] No `__NAVI_KEY__` placeholders leak in any shell's default output
- [ ] `cargo test` passes