### PR TITLE
Fix typos in doc comments and widgets docs

### DIFF
--- a/docs/widgets/README.md
+++ b/docs/widgets/README.md
@@ -3,7 +3,7 @@
 You want to launch Navi with a shortcut?\
 Widgets are here for you!
 
-Widgets are 3rd-party contributions and integrates Navi with 3rd-party software such as shells.
+Widgets are 3rd-party contributions and integrate Navi with 3rd-party software such as shells.
 
 ## List of shell widgets
 

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -12,8 +12,8 @@ use std::path::MAIN_SEPARATOR;
 
 use walkdir::WalkDir;
 
-/// Multiple paths are joint by a platform-specific separator.
-/// FIXME: it's actually incorrect to assume a path doesn't containing this separator
+/// Multiple paths are joined by a platform-specific separator.
+/// FIXME: it's actually incorrect to assume a path doesn't contain this separator
 #[cfg(target_family = "windows")]
 pub const JOIN_SEPARATOR: &str = ";";
 #[cfg(not(target_family = "windows"))]


### PR DESCRIPTION
Small grammar/typo fixes (comments + docs only):

- `src/filesystem.rs` — `Multiple paths are joint by a platform-specific separator` → `...are joined by...`.
- `src/filesystem.rs` — `assume a path doesn't containing this separator` → `...doesn't contain this separator`.
- `docs/widgets/README.md` — `Widgets are 3rd-party contributions and integrates Navi...` → `...and integrate Navi...` (agree with the plural subject).