### PR TITLE
Fix incorrect fzf minimum-version comparison

### DIFF
--- a/src/finder/mod.rs
+++ b/src/finder/mod.rs
@@ -76,9 +76,8 @@ impl FinderChoice {
 
         if let Self::Fzf = self {
             if let Some((major, minor, patch)) = Self::check_fzf_version() {
-                if major == MIN_FZF_VERSION_MAJOR
-                    && minor < MIN_FZF_VERSION_MINOR
-                    && patch < MIN_FZF_VERSION_PATCH
+                if (major, minor, patch)
+                    < (MIN_FZF_VERSION_MAJOR, MIN_FZF_VERSION_MINOR, MIN_FZF_VERSION_PATCH)
                 {
                     eprintln!(
                         "Warning: Fzf version {major}.{minor} does not support the preview window layout used by navi.",


### PR DESCRIPTION
### Problem

The minimum supported fzf version is `0.23.1` (`MIN_FZF_VERSION_*`), but the check in `src/finder/mod.rs` ANDs the three components independently:

```rust
if major == MIN_FZF_VERSION_MAJOR   // == 0
    && minor < MIN_FZF_VERSION_MINOR // < 23
    && patch < MIN_FZF_VERSION_PATCH // < 1  (i.e. patch == 0)
{
```

`patch < 1` is only true when `patch == 0`, so the warning fires for the wrong set of versions:

| fzf version | older than 0.23.1? | current check fires? |
|---|---|---|
| 0.22.0 | yes | ✅ yes |
| 0.22.5 | yes | ❌ **no** (5 < 1 is false) |
| 0.23.0 | yes | ❌ **no** (23 < 23 is false) |
| 0.23.1 | no | ✅ no |
| 1.0.0 | no | ✅ no |

So users on common too-old versions like `0.22.x` (x≥1) or `0.23.0` silently skip the warning, while only `*.*.0` versions are caught.

### Fix

Compare the version tuples lexicographically (Rust tuples already implement `Ord` this way), which correctly flags any version below the minimum:

```rust
if (major, minor, patch)
    < (MIN_FZF_VERSION_MAJOR, MIN_FZF_VERSION_MINOR, MIN_FZF_VERSION_PATCH)
{
```

No behavior change for versions ≥ 0.23.1; it only fixes the missed older versions.