### PR TITLE
fix: preserve multiline snippets in fish by clearing IFS locally

### DIFF
--- a/shell/navi.plugin.fish
+++ b/shell/navi.plugin.fish
@@ -1,6 +1,7 @@
 function _navi_smart_replace
     set --local query (commandline --current-process | string trim)
     set --local version_parts ""
+    set --local IFS
     if test -n "$version"
         set version_parts (string split '.' $version)
     else


### PR DESCRIPTION
## Problem

When using the latest up-to-date widget in Fish shell, multi-line input is rendered as a single line instead of preserving line breaks.

## Fix

Declare a local empty IFS before capturing the output of `navi`.

Without this, Fish splits multiline command substitutions into a list, causing `commandline --replace` to flatten the snippet into a single line.

Using a local empty IFS preserves the multiline output while keeping the change scoped to `_navi_smart_replace`.