### PR TITLE
Fix variable query override precedence

### DIFF
--- a/src/commands/core/actor.rs
+++ b/src/commands/core/actor.rs
@@ -12,6 +12,10 @@ use crate::structures::item::Item;
 use shell::EOF;
 use std::process::Stdio;
 
+fn query_with_override(query: Option<String>, query_override: Option<String>) -> Option<String> {
+    query_override.or(query)
+}
+
 fn prompt_finder(
     variable_name: &str,
     suggestion: Option<&Suggestion>,
@@ -116,7 +120,7 @@ fn prompt_finder(
         ..initial_opts.clone().unwrap_or_else(FinderOpts::var_default)
     };
 
-    opts.query = env_var::get(format!("{variable_name}__query")).ok();
+    opts.query = query_with_override(opts.query, env_var::get(format!("{variable_name}__query")).ok());
 
     if let Ok(f) = env_var::get(format!("{variable_name}__best")) {
         opts.filter = Some(f);
@@ -259,4 +263,25 @@ pub fn act(
     };
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::query_with_override;
+
+    #[test]
+    fn preserves_query_without_override() {
+        assert_eq!(
+            query_with_override(Some("cheatsheet query".into()), None),
+            Some("cheatsheet query".into())
+        );
+    }
+
+    #[test]
+    fn query_override_wins() {
+        assert_eq!(
+            query_with_override(Some("cheatsheet query".into()), Some("environment query".into())),
+            Some("environment query".into())
+        );
+    }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -347,4 +347,11 @@ mod tests {
         assert_eq!(opts.delimiter, None);
         assert_eq!(opts.suggestion_type, SuggestionType::SingleSelection);
     }
+
+    #[test]
+    fn parses_variable_query() {
+        let (_, _, command_options) = parse_variable_line("$ title: echo titles --- --query test").unwrap();
+
+        assert_eq!(command_options.unwrap().query.as_deref(), Some("test"));
+    }
 }


### PR DESCRIPTION
## Summary

- preserve a cheatsheet variable query when no `<variable>__query` environment override exists
- keep the environment query as the higher-precedence override
- test both precedence paths and variable-line query parsing

## Testing

- `cargo fmt --all -- --check`
- `cargo test` (Rust 1.81 Linux container)
- `cargo check --all-targets`
- `cargo clippy -- -D warnings` (Windows and Rust 1.81 Linux container)

Fixes #920

## Disclosure

This pull request was implemented and tested with assistance from OpenAI's OpenCode coding agent.