### PR TITLE
Shell-escape variable values before splicing into snippet commands

### DIFF
--- a/src/commands/core/actor.rs
+++ b/src/commands/core/actor.rs
@@ -189,7 +189,14 @@ fn replace_variables_from_snippet(snippet: &str, tags: &str, variables: Variable
         interpolated_snippet = if value.as_str() == "\n" {
             interpolated_snippet.replacen(bracketed_variable_name, "", 1)
         } else {
-            interpolated_snippet.replacen(bracketed_variable_name, value.as_str(), 1)
+            // The value may originate from a suggestion command's output
+            // (e.g. a file, process, or branch name), which is not
+            // controlled by the cheatsheet author and can contain shell
+            // metacharacters. Escape it before splicing it into the
+            // snippet, since the interpolated snippet is executed via a
+            // shell.
+            let escaped_value = shellwords::escape(value.as_str());
+            interpolated_snippet.replacen(bracketed_variable_name, &escaped_value, 1)
         };
     }
 
@@ -282,5 +289,37 @@ mod tests {
             query_with_override(Some("cheatsheet query".into()), Some("environment query".into())),
             Some("environment query".into())
         );
+    }
+
+    /// Regression test for shell command injection via an unescaped
+    /// variable value. A variable's value can come from a suggestion
+    /// command's output (e.g. a file name), which is not controlled by
+    /// the cheatsheet author and can contain shell metacharacters. The
+    /// interpolated snippet is executed via a shell, so the value must
+    /// be escaped before substitution, not spliced in as raw text.
+    ///
+    /// This drives replace_variables_from_snippet through the
+    /// environment-variable-override path (the same code path prompt_finder
+    /// would otherwise populate interactively), since that's the most
+    /// direct way to supply a specific value without mocking the finder.
+    #[test]
+    fn escapes_shell_metacharacters_in_variable_values() {
+        use crate::structures::cheat::VariableMap;
+
+        let malicious_value = "x; touch injected; echo x";
+        std::env::set_var("file", malicious_value);
+
+        let result = super::replace_variables_from_snippet(
+            "echo selected: <file>",
+            "",
+            VariableMap::default(),
+        )
+        .unwrap();
+
+        std::env::remove_var("file");
+
+        // The malicious value must appear escaped, not as raw shell
+        // syntax that a shell would split into multiple commands.
+        assert_eq!(result, "echo selected: x\\;\\ touch\\ injected\\;\\ echo\\ x");
     }
 }


### PR DESCRIPTION
Fixes #1037.

## Summary

`replace_variables_from_snippet` (src/commands/core/actor.rs) spliced a
resolved variable's value directly into the snippet's command template
via a plain string replacement, with no shell escaping, before the
interpolated string was executed via `<shell> -c`. A variable's value
can come from a suggestion command's output declared in the cheatsheet
(a common, documented feature, e.g. `$ file: ls`), which is not
controlled by the cheatsheet author. Since file names on Linux impose
essentially no character restriction, a suggestion list built from file
names could present a value that looks like an ordinary item to pick
while containing shell metacharacters; selecting it injected those
characters into the command that ran, not merely as an extra argument
but as separate shell commands.

## Fix

Escapes the resolved value with `shellwords::escape` (already a
dependency, used elsewhere for splitting but not previously for
escaping) before substitution, so any shell metacharacters it contains
are treated as literal text.

## Testing

- `cargo test --release` passes in full (27 passed, up from 26 with the
  new test, 0 failed).
- Added `escapes_shell_metacharacters_in_variable_values`, which drives
  `replace_variables_from_snippet` through the environment-variable-
  override code path (the same path `prompt_finder` would otherwise
  populate interactively) with a value containing semicolons and spaces,
  and asserts the interpolated result is the escaped form rather than
  raw shell syntax.
- Manually reproduced the issue against an unpatched build: created a
  minimal custom cheatsheet with a `$ file: ls <dir>`-style suggestion,
  placed a file whose name was a shell-metacharacter payload
  (`x; touch injected; echo x`) in that directory, and drove navi
  interactively (tmux, since the finder needs a terminal) through
  selecting the snippet and then that file suggestion. The output showed
  two separate `echo` results and a marker file created by the injected
  `touch`, confirming command execution. Repeated against this branch:
  the output showed the full filename printed literally on one line, and
  no marker file was created.
