### PR TITLE
fish: stop the widget reopening fzf over its own best match

### DIFF
--- a/docs/widgets/README.md
+++ b/docs/widgets/README.md
@@ -10,10 +10,18 @@ Widgets are 3rd-party contributions and integrate Navi with 3rd-party software s
 | Shell      | Navi support       |
 |------------|--------------------|
 | Bash       | :white_check_mark: |
-| Fish       |                    |
-| Zsh        |                    |
+| Fish       | :white_check_mark: |
+| Zsh        | :white_check_mark: |
 | NuShell    | :white_check_mark: |
 | PowerShell | :white_check_mark: |
+
+## Fish Widget
+
+The fish widget replaces the command under the cursor, so anything to the left of a pipe or a `&&` is left alone.
+
+- on an empty prompt, `Ctrl+G` opens the picker
+- with something typed, `Ctrl+G` replaces it with the best match for it, without opening the picker
+- pressing `Ctrl+G` again, before editing that result, opens the picker with your original text as the query
 
 ## PowerShell Widget
 

--- a/shell/navi.plugin.fish
+++ b/shell/navi.plugin.fish
@@ -1,13 +1,21 @@
 function _navi_smart_replace
-    set --local query (commandline --current-process | string trim)
-    set --local version_parts ""
-    set --local IFS
-    if test -n "$version"
-        set version_parts (string split '.' $version)
-    else
-        set version_parts (string split '.' (string match -r '\d+\.\d+\.\d+' (fish --version)))
+    set --local buffer (commandline --current-buffer | string collect)
+    set --local process (commandline --current-process | string collect)
+    # --current-process hands back the whitespace separating the command from a
+    # preceding pipe or operator, so keep it to splice it back in afterwards
+    set --local indent (string match --regex '^\s*' -- "$process")
+    set --local query (string trim -- "$process")
+
+    # A second press on a result we spliced and the user hasn't edited means the
+    # best match was wrong, so fall through to the picker seeded with the query
+    # that produced it. Mirrors the $LASTWIDGET check in the zsh widget.
+    set --local repeat false
+    if test -n "$_navi_last_buffer"; and test "$buffer" = "$_navi_last_buffer"
+        set repeat true
+        set query $_navi_last_query
     end
 
+    set --local major (string match --regex '^\d+' -- "$FISH_VERSION")
     set --local force_repaint false
     # https://github.com/fish-shell/fish-shell/blob/d663f553dffba460d6d0bcdf93df21bda9ec6f3f/doc_src/interactive.rst?plain=1#L440
     #  > Bindings that change the mode are supposed to call the repaint-mode bind function
@@ -18,26 +26,32 @@ function _navi_smart_replace
     #  - https://github.com/fish-shell/fish-shell/blob/d663f553dffba460d6d0bcdf93df21bda9ec6f3f/src/screen.rs#L531
     #
     # Introduced with: https://github.com/denisidoro/navi/pull/982
-    if test $version_parts[1] -ge 4
+    if test -n "$major"; and test "$major" -ge 4
         set force_repaint true
     end
 
-    if test -n "$query"
-        set --local best_match (navi --print --query "$query" --best-match)
-        if test -n "$best_match"
-            # --replace without --current-process: --current-process treats newlines as process
-            # boundaries and flattens multi-line snippets into a single line
-            commandline --replace -- "$best_match"
-            commandline --function end-of-line
+    # `string collect` keeps a multi-line snippet as a single value; without it
+    # command substitution splits it per line and expansion flattens those lines
+    # back into one
+    set --local snippet ""
+    if test -z "$query"
+        set snippet (navi --print | string collect)
+    else if test "$repeat" = true
+        set snippet (navi --print --query "$query" | string collect)
+    else
+        set snippet (navi --print --query "$query" --best-match | string collect)
+        if test -z "$snippet"
+            set snippet (navi --print --query "$query" | string collect)
         end
     end
 
-    if test -z "$best_match"
-        set --local candidate (navi --print --query "$query")
-        if test -n "$candidate"
-            commandline --replace -- "$candidate"
-            commandline --function end-of-line
-        end
+    if test -n "$snippet"
+        # --current-process so that anything before the command under the
+        # cursor, e.g. the left-hand side of a pipe, survives the replacement
+        commandline --current-process --replace -- "$indent$snippet"
+        commandline --function end-of-line
+        set --global _navi_last_buffer (commandline --current-buffer | string collect)
+        set --global _navi_last_query "$query"
     end
 
     # always repaint to restore the prompt after fzf clobbers the terminal
@@ -46,5 +60,7 @@ function _navi_smart_replace
     end
 end
 
-bind \cg _navi_smart_replace
-bind --mode insert \cg _navi_smart_replace
+if status is-interactive
+    bind \cg _navi_smart_replace
+    bind --mode insert \cg _navi_smart_replace
+end

--- a/tests/shell/lib.bash
+++ b/tests/shell/lib.bash
@@ -23,6 +23,9 @@ readonly SHELL_TESTS_RC_DIR="${SHELL_TESTS_HOME}/rc"
 # need a beat to start, especially on cold CI runners.
 readonly SHELL_TESTS_WAIT_TIMEOUT="${SHELL_TESTS_WAIT_TIMEOUT:-15}"
 
+# fzf's "matches/total" counter, i.e. proof that the picker is on screen.
+readonly SHELL_TESTS_FZF_REGEX='[0-9]+/[0-9]+'
+
 # Display marker for bash/zsh PS1/PROMPT and fish "$SHELL_TESTS_PROMPT_TEXT".
 readonly SHELL_TESTS_PROMPT_MARKER='NAVIPROMPT> '
 # Pane detection: tmux capture-pane often strips trailing spaces, so match
@@ -114,6 +117,25 @@ shell::wait_for() {
 
 shell::wait_for_prompt() {
    shell::wait_for "$1" "$SHELL_TESTS_PROMPT_REGEX" "${2:-}"
+}
+
+# Assert `pattern` (extended regex) never shows up in the pane. Polls for
+# `settle` seconds rather than checking once, so a pane that is merely slow
+# to render is still caught. Returns 0 if absent, 1 if it appeared.
+shell::refute_appears() {
+   local -r session="$1"
+   local -r pattern="$2"
+   local -r settle="${3:-3}"
+   local -r deadline=$(( $(date +%s) + settle ))
+
+   while [ "$(date +%s)" -lt "$deadline" ]; do
+      if shell::pane "$session" | grep -Eq "$pattern"; then
+         return 1
+      fi
+      sleep 0.2
+   done
+
+   return 0
 }
 
 # Start a fresh tmux session for the given shell. Returns the session

--- a/tests/shell/run
+++ b/tests/shell/run
@@ -59,9 +59,8 @@ case::query_driven() {
    shell::trigger "$session"
 
    local -r snippet_marker='echo "NAVI_TEST::ping_ok::END"'
-   local -r fzf_marker='[0-9]+/[0-9]+'
 
-   if ! shell::wait_for "$session" "(${snippet_marker}|${fzf_marker})"; then
+   if ! shell::wait_for "$session" "(${snippet_marker}|${SHELL_TESTS_FZF_REGEX})"; then
       log::error "[$shell] neither snippet nor fzf appeared after C-g"
       shell::pane "$session" 1>&2
       shell::stop "$session"
@@ -109,9 +108,8 @@ case::multiline_preserved() {
    shell::trigger "$session"
 
    local -r snippet_marker='NAVI_TEST::multi_line_1::END'
-   local -r fzf_marker='[0-9]+/[0-9]+'
 
-   if ! shell::wait_for "$session" "(${snippet_marker}|${fzf_marker})"; then
+   if ! shell::wait_for "$session" "(${snippet_marker}|${SHELL_TESTS_FZF_REGEX})"; then
       log::error "[$shell] multi-line snippet did not appear after C-g"
       shell::pane "$session" 1>&2
       shell::stop "$session"
@@ -138,6 +136,136 @@ case::multiline_preserved() {
    fi
    if [ "$rc" -eq 0 ] && ! shell::wait_for "$session" 'NAVI_TEST::multi_line_2::END' "${SHELL_TESTS_MULTILINE_TIMEOUT:-15}"; then
       log::error "[$shell] second sentinel not on its own output line (newlines were likely flattened)"
+      shell::pane "$session" 1>&2
+      rc=1
+   fi
+
+   shell::stop "$session"
+   return "$rc"
+}
+
+# Regression test for https://github.com/denisidoro/navi/issues/1017.
+#
+# When `--best-match` already answered the query the widget must splice it in
+# and stop. The fish plugin used to test a variable that fish had already
+# destroyed at the end of its enclosing `if` block, so the fallback always
+# fired and fzf popped up on top of the snippet it had just inserted.
+#
+# Not run for bash, whose widget has no --best-match path and always picks.
+case::best_match_skips_picker() {
+   local -r shell="$1"
+   local session
+   session="$(shell::start "$shell" "bestmatch")" || return 1
+
+   shell::type "$session" "ping"
+   shell::trigger "$session"
+
+   local rc=0
+   if ! shell::wait_for "$session" 'echo "NAVI_TEST::ping_ok::END"'; then
+      log::error "[$shell] --best-match snippet never reached the buffer"
+      shell::pane "$session" 1>&2
+      rc=1
+   fi
+
+   if [ "$rc" -eq 0 ] && ! shell::refute_appears "$session" "$SHELL_TESTS_FZF_REGEX"; then
+      log::error "[$shell] fzf opened even though --best-match already matched"
+      shell::pane "$session" 1>&2
+      rc=1
+   fi
+
+   shell::stop "$session"
+   return "$rc"
+}
+
+# A second Ctrl-G on an untouched best match is the documented escape hatch
+# into the interactive picker (zsh does this via $LASTWIDGET, fish by
+# remembering the buffer it wrote). Without it, `--best-match` would be the
+# only reachable behaviour for a non-empty prompt.
+case::repeat_press_opens_picker() {
+   local -r shell="$1"
+   local session
+   session="$(shell::start "$shell" "repeat")" || return 1
+
+   shell::type "$session" "ping"
+   shell::trigger "$session"
+
+   local rc=0
+   if ! shell::wait_for "$session" 'echo "NAVI_TEST::ping_ok::END"'; then
+      log::error "[$shell] --best-match snippet never reached the buffer"
+      shell::pane "$session" 1>&2
+      shell::stop "$session"
+      return 1
+   fi
+
+   shell::trigger "$session"
+   if ! shell::wait_for "$session" "$SHELL_TESTS_FZF_REGEX"; then
+      log::error "[$shell] second C-g did not open the picker"
+      shell::pane "$session" 1>&2
+      shell::stop "$session"
+      return 1
+   fi
+
+   # Accepting leaves the same snippet in the buffer, so the assertions below
+   # hold whether the picker had a match to offer or not.
+   shell::enter "$session"
+   if ! shell::wait_for "$session" 'echo "NAVI_TEST::ping_ok::END"'; then
+      log::error "[$shell] buffer lost the snippet after accepting the picker"
+      shell::pane "$session" 1>&2
+      shell::stop "$session"
+      return 1
+   fi
+
+   shell::enter "$session"
+   if ! shell::wait_for "$session" '^NAVI_TEST::ping_ok::END'; then
+      log::error "[$shell] sentinel never appeared after running buffer"
+      shell::pane "$session" 1>&2
+      rc=1
+   fi
+
+   shell::stop "$session"
+   return "$rc"
+}
+
+# Regression test for https://github.com/denisidoro/navi/issues/1017.
+#
+# Only the command under the cursor may be replaced. The fish plugin used to
+# call `commandline --replace`, which rewrites the whole buffer and threw away
+# everything to the left of the pipe.
+case::prefix_preserved() {
+   local -r shell="$1"
+   local session
+   session="$(shell::start "$shell" "prefix")" || return 1
+
+   shell::type "$session" "true | ping"
+   shell::trigger "$session"
+
+   local -r spliced='true | echo "NAVI_TEST::ping_ok::END"'
+   # same string as an extended regex: the pipe would otherwise alternate
+   local -r spliced_regex='true \| echo "NAVI_TEST::ping_ok::END"'
+
+   if ! shell::wait_for "$session" "(${spliced_regex}|${SHELL_TESTS_FZF_REGEX})"; then
+      log::error "[$shell] neither snippet nor fzf appeared after C-g"
+      shell::pane "$session" 1>&2
+      shell::stop "$session"
+      return 1
+   fi
+
+   # bash always opens the picker; accept the single match.
+   if ! shell::pane "$session" | grep -Fq "$spliced"; then
+      shell::enter "$session"
+      if ! shell::wait_for "$session" "$spliced_regex"; then
+         log::error "[$shell] left-hand side of the pipe did not survive the replacement"
+         shell::pane "$session" 1>&2
+         shell::stop "$session"
+         return 1
+      fi
+   fi
+
+   shell::enter "$session"
+
+   local rc=0
+   if ! shell::wait_for "$session" '^NAVI_TEST::ping_ok::END'; then
+      log::error "[$shell] sentinel never appeared after running buffer"
       shell::pane "$session" 1>&2
       rc=1
    fi
@@ -173,6 +301,14 @@ for shell in bash zsh fish; do
    fi
    test::set_suite "${shell} regressions"
    test::run "multiline_snippet (#1010)" case::multiline_preserved "$shell"
+   test::run "pipe_prefix (#1017)"       case::prefix_preserved    "$shell"
+
+   # bash's widget always opens the picker, so it has neither a --best-match
+   # shortcut to skip nor a second-press escape hatch out of one.
+   if [ "$shell" != "bash" ]; then
+      test::run "best_match_skips_picker (#1017)"   case::best_match_skips_picker   "$shell"
+      test::run "repeat_press_opens_picker (#1017)" case::repeat_press_opens_picker "$shell"
+   fi
 done
 
 test::finish


### PR DESCRIPTION
`Ctrl+G` in fish silently replaced the prompt with a `--best-match` result and then immediately reopened fzf on top of it, so the widget never behaved the way the demo shows. This fixes that, restores prefix-preserving replacement, and adds regression coverage.

Fixes #1017

## Root cause 1: a variable fish had already destroyed

```fish
if test -n "$query"
    set --local best_match (navi --print --query "$query" --best-match)
    ...
end

if test -z "$best_match"      # always true
```

fish erases `--local` variables when their enclosing block ends, and `if` is a block, so `$best_match` was always empty by the time the fallback tested it. Every `Ctrl+G` on a non-empty prompt ran navi twice: splice in the best match, then open the picker over what it had just inserted. This came in with aa87ad4 (#1032), which swapped an early `return` for a check on the now out-of-scope variable.

The fix hoists the result to function scope, so the fallback only runs when `--best-match` genuinely found nothing.

## Root cause 2: the whole buffer was being replaced

#1010 changed the splice to `commandline --replace`, which rewrites the entire command line rather than the command under the cursor:

```
before:   true | ping   ->   echo "..."
after:    true | ping   ->   true | echo "..."
```

The flattening that #1010 set out to fix was really `$best_match` being an unquoted fish list. `string collect` addresses that at the source, so the splice can go back to `commandline --current-process` and keep the left-hand side of the pipe. That also let me drop the empty `$IFS`, which silently changes `read` semantics for anything else in scope.

## A second press still reaches the picker

With the fallthrough fixed, a non-empty prompt would otherwise only ever get `--best-match`. zsh solves this with `$LASTWIDGET`; fish now remembers the buffer it wrote, so pressing `Ctrl+G` again on a result you haven't edited opens the picker seeded with your original query.

## Smaller things

- `$FISH_VERSION` replaces `$version` plus an unreachable `fish --version` fallback, and the `-ge 4` comparison no longer errors on a non-numeric major
- `bind` is guarded by `status is-interactive`
- Fish and Zsh get their checkmark in the widget support table. That was the other half of #1017: the table said unsupported while the same page documented how to install them. Added a short section on the two-press behaviour too.

## Tests

Three new cases in `tests/shell/run`, already covered by the existing `shell/**` path filter in CI. All three fail against the old plugin with exactly the symptoms above and pass against the new one. The pre-existing `query_driven` and `multiline_snippet` cases passed either way, which is how #1017 slipped through.

- `best_match_skips_picker (#1017)` (zsh, fish): the snippet lands in the buffer and fzf never appears
- `repeat_press_opens_picker (#1017)` (zsh, fish): a second `Ctrl+G` opens the picker and the buffer survives accepting it
- `pipe_prefix (#1017)` (bash, zsh, fish): the left-hand side of a pipe survives the replacement and the result runs

`./tests/shell/run` passes 16/16 locally against fish 4.8.1, zsh 5.9, bash 5.3, tmux 3.7b and fzf 0.74.2. CI covers fish 3.7 on Ubuntu.

Also checked by hand: empty prompt opens the picker, a typed query gets its best match, a second press opens the picker, the pipe prefix survives, multi-line snippets stay on separate lines, and vi mode keeps its `[I]` indicator after the repaint.
